### PR TITLE
Feature/tx timestamp

### DIFF
--- a/accounts/abi/bind/backends/dropped_tx_subscription.go
+++ b/accounts/abi/bind/backends/dropped_tx_subscription.go
@@ -2,7 +2,9 @@ package backends
 
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
 
@@ -13,4 +15,8 @@ func (fb *filterBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) even
 
 func (fb *filterBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription {
 	return nullSubscription()
+}
+
+func (fb *filterBackend) GetPoolTransaction(hash common.Hash) *types.Transaction {
+	return nil
 }

--- a/core/events.go
+++ b/core/events.go
@@ -28,7 +28,7 @@ type NewTxsEvent struct{ Txs []*types.Transaction }
 type DropTxsEvent struct{
 	Txs []*types.Transaction
 	Reason string
-	Replacement common.Hash
+	Replacement *types.Transaction
 }
 
 // RejectedTxEvent is posted when a transaction is rejected from entering the transaction pool

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -664,7 +664,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			pool.dropTxFeed.Send(DropTxsEvent{
 				Txs: []*types.Transaction{old},
 				Reason: dropReplaced,
-				Replacement: tx.Hash(),
+				Replacement: tx,
 			})
 		}
 		pool.all.Add(tx, isLocal)

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -45,6 +45,8 @@ type Backend interface {
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
 
+	GetPoolTransaction(hash common.Hash) *types.Transaction
+
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
 }


### PR DESCRIPTION
This adds a p2pts for both newPendingTransactionsWithPeers *and* newHeadsWithPeers, which indicates when those items were received by the peer-to-peer subsystems, before they were validated.

Note that this PR is on top of #6, which has not currently been merged.