### PR TITLE
Feature/full blocks feed

### DIFF
--- a/accounts/abi/bind/backends/dropped_tx_subscription.go
+++ b/accounts/abi/bind/backends/dropped_tx_subscription.go
@@ -2,6 +2,7 @@ package backends
 
 
 import (
+	"context"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,4 +20,7 @@ func (fb *filterBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent
 
 func (fb *filterBackend) GetPoolTransaction(hash common.Hash) *types.Transaction {
 	return nil
+}
+func (fb *filterBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return nil, nil
 }

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -49,6 +49,7 @@ type Backend interface {
 
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
+	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 }
 
 // Filter can be used to retrieve and filter logs.


### PR DESCRIPTION
Remove dropped transactions from the tsMap and txPeerMap, which should eliminate records indicating transactions are 5 minutes old. 

Also adds a new feed for blocks, including transactions and transaction receipts.

@cmeisl was fairly concerned that the addition of transactions and transaction receipts not require too much recalculation. While this does get the block (including the transactions) and the receipts from the blockchain backend, for a block that has *just* been emitted through the chainEvent feeds, it should be extremely rare that these values would not be present in the cache. I can't totally eliminate the possibility that it could happen (and if it does happen data will be retrieved from disk as needed), but it should be very rare.