### PR TITLE
Better cleanup of transaction p2p timestamps

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -283,6 +283,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 	errs := f.addTxs(txs)
 	for i, err := range errs {
 		if err != nil {
+			filters.ClearTxTimestamp(txs[i].Hash())
 			// Track the transaction hash if the price is too low for us.
 			// Avoid re-request this transaction when we receive another
 			// announcement.

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -68,6 +68,7 @@ func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration) 
 		timeout: timeout,
 	}
 	go api.timeoutLoop(timeout)
+	go api.dropLoop()
 
 	return api
 }

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -116,8 +116,8 @@ func (api *PublicFilterAPI) dropLoop() {
 	for d := range dropped {
 		for _, tx := range d.Txs {
 			h := tx.Hash()
-			tsMap.Remove(h)
-			txPeerMap.Remove(h)
+			if tsMap != nil { tsMap.Remove(h) }
+			if txPeerMap != nil { txPeerMap.Remove(h) }
 		}
 	}
 }

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -84,7 +84,6 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 			select {
 			case d := <-dropped:
 				for _, tx := range d.Txs {
-					h := tx.Hash()
 					notification := &dropNotification{
 						Tx: newRPCPendingTransaction(tx),
 						Reason: d.Reason,
@@ -92,12 +91,10 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 						Time: time.Now().UnixNano(),
 					}
 					if d.Replacement != nil {
-						peerid, _ := txPeerMap.Get(h)
+						peerid, _ := txPeerMap.Get(tx.Hash())
 						notification.Peer, _ = peerIDMap.Load(peerid)
 					}
 					notifier.Notify(rpcSub.ID, notification)
-					tsMap.Remove(h)
-					txPeerMap.Remove(h)
 				}
 			case <-rpcSub.Err():
 				droppedSub.Unsubscribe()
@@ -110,6 +107,19 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 	}()
 
 	return rpcSub, nil
+}
+
+func (api *PublicFilterAPI) dropLoop() {
+	dropped := make(chan core.DropTxsEvent)
+	droppedSub := api.backend.SubscribeDropTxsEvent(dropped)
+	defer droppedSub.Unsubscribe()
+	for d := range dropped {
+		for _, tx := range d.Txs {
+			h := tx.Hash()
+			tsMap.Remove(h)
+			txPeerMap.Remove(h)
+		}
+	}
 }
 
 // RejectedTransactions send a notification each time a transaction is rejected from entering the mempool

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -64,6 +64,10 @@ func SetTxPeer(hash common.Hash, peer string) {
 	}
 }
 
+func ClearTxTimestamp(hash common.Hash) {
+	tsMap.Remove(hash)
+}
+
 // SubscribePeerIDs tracks and populates the peerID map with the ID and enode,
 // so that they can be provided in responses with transaction and block
 // information


### PR DESCRIPTION
The timestamps recorded when transactions are received weren't
being cleared when transactions were dropped or rejected. This could
mean that a transaction was dropped or rejected due to insufficient
price (or perhaps other reasons), but the timestamp would be retained
until it was seen again, and the earlier timestamp would be used
with a later receipt of the transaction.

This ensures that rejected transactions are removed from the timestamp
map as soon as they are rejected, and stops relying on the drop feed
(which may have no subscribers) for removing timestamps on dropped
transactions.