### PR TITLE
Feature/revert reason feed

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -100,6 +100,10 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 		return nil, err
 	}
 
+	if revert := result.Revert(); revert != nil {
+		CacheRevertReason(tx.Hash(), revert)
+	}
+
 	// Update the state with pending changes.
 	var root []byte
 	if config.IsByzantium(header.Number) {

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -283,6 +283,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 	errs := f.addTxs(txs)
 	for i, err := range errs {
 		if err != nil {
+			filters.ClearTxTimestamp(txs[i].Hash())
 			// Track the transaction hash if the price is too low for us.
 			// Avoid re-request this transaction when we receive another
 			// announcement.

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -68,6 +68,7 @@ func NewPublicFilterAPI(backend Backend, lightMode bool, timeout time.Duration) 
 		timeout: timeout,
 	}
 	go api.timeoutLoop(timeout)
+	go api.dropLoop()
 
 	return api
 }

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -84,7 +84,6 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 			select {
 			case d := <-dropped:
 				for _, tx := range d.Txs {
-					h := tx.Hash()
 					notification := &dropNotification{
 						Tx: newRPCPendingTransaction(tx),
 						Reason: d.Reason,
@@ -92,12 +91,10 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 						Time: time.Now().UnixNano(),
 					}
 					if d.Replacement != nil {
-						peerid, _ := txPeerMap.Get(h)
+						peerid, _ := txPeerMap.Get(tx.Hash())
 						notification.Peer, _ = peerIDMap.Load(peerid)
 					}
 					notifier.Notify(rpcSub.ID, notification)
-					tsMap.Remove(h)
-					txPeerMap.Remove(h)
 				}
 			case <-rpcSub.Err():
 				droppedSub.Unsubscribe()
@@ -110,6 +107,19 @@ func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subsc
 	}()
 
 	return rpcSub, nil
+}
+
+func (api *PublicFilterAPI) dropLoop() {
+	dropped := make(chan core.DropTxsEvent)
+	droppedSub := api.backend.SubscribeDropTxsEvent(dropped)
+	defer droppedSub.Unsubscribe()
+	for d := range dropped {
+		for _, tx := range d.Txs {
+			h := tx.Hash()
+			tsMap.Remove(h)
+			txPeerMap.Remove(h)
+		}
+	}
 }
 
 // RejectedTransactions send a notification each time a transaction is rejected from entering the mempool

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -14,6 +14,7 @@ package filters
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	// "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -206,6 +207,9 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 					// If the ContractAddress is 20 0x0 bytes, assume it is not a contract creation
 					if receipt.ContractAddress != (common.Address{}) {
 						fields["contractAddress"] = receipt.ContractAddress
+					}
+					if reason, ok := core.GetRevertReason(receipt.TxHash); ok {
+						fields["revertReason"] = reason
 					}
 					marshalReceipts[receipt.TxHash] = fields
 				}

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -64,6 +64,10 @@ func SetTxPeer(hash common.Hash, peer string) {
 	}
 }
 
+func ClearTxTimestamp(hash common.Hash) {
+	tsMap.Remove(hash)
+}
+
 // SubscribePeerIDs tracks and populates the peerID map with the ID and enode,
 // so that they can be provided in responses with transaction and block
 // information


### PR DESCRIPTION
The NewFullBlocksWithPeers feed now includes a revert reason inside the receipts. This is cached during block processing to avoid recomputation.