### PR TITLE
add nil tx check

### DIFF
--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -32,6 +32,9 @@ type rejectNotification struct {
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
 func newRPCPendingTransaction(tx *types.Transaction) *ethapi.RPCTransaction {
+	if tx == nil {
+		return nil
+	}
 	var signer types.Signer
 	if tx.Protected() {
 		signer = types.LatestSignerForChainID(tx.ChainId())


### PR DESCRIPTION
Adds nil tx check back to `newRPCPendingTransaction` handler which was accidentally removed in the last PR https://github.com/blocknative/go-ethereum/pull/12/files#diff-4c749681b46f7485aaf69749644b6abe20ccab355a64519ccb7f665ecbd08f10L35