### PR TITLE
Feature/queued feed

### DIFF
--- a/accounts/abi/bind/backends/dropped_tx_subscription.go
+++ b/accounts/abi/bind/backends/dropped_tx_subscription.go
@@ -14,6 +14,10 @@ func (fb *filterBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) even
 	return nullSubscription()
 }
 
+func (fb *filterBackend) SubscribeQueuedTxsEvent(ch chan<- *types.Transaction) event.Subscription {
+	return nullSubscription()
+}
+
 func (fb *filterBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription {
 	return nullSubscription()
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -227,6 +227,8 @@ type TxPool struct {
 	chain        blockChain
 	gasPrice     *big.Int
 	txFeed       event.Feed
+	queuedTxFeed event.Feed
+	recentlyQueued map[common.Hash]*types.Transaction
 	dropTxFeed   event.Feed
 	rejectTxFeed event.Feed
 	scope        event.SubscriptionScope
@@ -287,6 +289,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		reorgDoneCh:     make(chan chan struct{}),
 		reorgShutdownCh: make(chan struct{}),
 		gasPrice:        new(big.Int).SetUint64(config.PriceLimit),
+		recentlyQueued:  make(map[common.Hash]*types.Transaction),
 	}
 	pool.locals = newAccountSet(pool.signer)
 	for _, addr := range config.Locals {
@@ -426,6 +429,11 @@ func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- NewTxsEvent) event.Subscripti
 // starts sending event to the given channel.
 func (pool *TxPool) SubscribeDropTxsEvent(ch chan<- DropTxsEvent) event.Subscription {
 	return pool.scope.Track(pool.dropTxFeed.Subscribe(ch))
+}
+// SubscribeQueuedTxsEvent registers a subscription of Transaction and
+// starts sending event to the given channel.
+func (pool *TxPool) SubscribeQueuedTxsEvent(ch chan<- *types.Transaction) event.Subscription {
+	return pool.scope.Track(pool.queuedTxFeed.Subscribe(ch))
 }
 
 // SubscribeRejectedTxEvent registers a subscription of RejectedTxEvent and
@@ -771,6 +779,7 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction, local boo
 		queuedDiscardMeter.Mark(1)
 		return false, ErrReplaceUnderpriced
 	}
+	pool.recentlyQueued[hash] = tx
 	// Discard any previous transaction and mark this
 	if old != nil {
 		pool.all.Remove(old.Hash())
@@ -1220,6 +1229,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 			events[addr] = newTxSortedMap()
 		}
 		events[addr].Put(tx)
+		delete(pool.recentlyQueued, tx.Hash())
 	}
 	if len(events) > 0 {
 		var txs []*types.Transaction
@@ -1227,6 +1237,10 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 			txs = append(txs, set.Flatten()...)
 		}
 		pool.txFeed.Send(NewTxsEvent{txs})
+	}
+	for hash, tx := range pool.recentlyQueued {
+		pool.queuedTxFeed.Send(tx)
+		delete(pool.recentlyQueued, hash)
 	}
 }
 

--- a/eth/dropped_tx_subscription.go
+++ b/eth/dropped_tx_subscription.go
@@ -9,8 +9,13 @@ package eth
 
 import (
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
+
+func (b *EthAPIBackend)  SubscribeQueuedTxsEvent(ch chan<- *types.Transaction) event.Subscription {
+	return b.eth.TxPool().SubscribeQueuedTxsEvent(ch)
+}
 
 func (b *EthAPIBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
 	return b.eth.TxPool().SubscribeDropTxsEvent(ch)

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -180,3 +180,40 @@ func (api *PublicFilterAPI) RejectedTransactions(ctx context.Context) (*rpc.Subs
 
 	return rpcSub, nil
 }
+
+
+// NewQueuedTransactionsWithPeers send a notification each time a transaction is queued
+func (api *PublicFilterAPI) NewQueuedTransactionsWithPeers(ctx context.Context) (*rpc.Subscription, error) {
+	if txPeerMap == nil { txPeerMap, _ = lru.New(100000) }
+	if peerIDMap == nil { peerIDMap = &sync.Map{} }
+	if tsMap == nil { tsMap, _ = lru.New(100000) }
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		queued := make(chan *types.Transaction)
+		droppedSub := api.backend.SubscribeQueuedTxsEvent(queued)
+
+		for {
+			select {
+			case tx := <-queued:
+				peerid, _ := txPeerMap.Get(tx.Hash())
+				p2pts, _ := tsMap.Get(tx.Hash())
+				peer, _ := peerIDMap.Load(peerid)
+				notifier.Notify(rpcSub.ID, withPeer{Value: newRPCPendingTransaction(tx), Peer: peer, Time: time.Now().UnixNano(), P2PTime: p2pts})
+			case <-rpcSub.Err():
+				droppedSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				droppedSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -39,6 +39,7 @@ type Backend interface {
 
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription
+	SubscribeQueuedTxsEvent(ch chan<- *types.Transaction) event.Subscription
 	SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -81,6 +81,7 @@ type Backend interface {
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeRejectedTxEvent(chan<- core.RejectedTxEvent) event.Subscription
 	SubscribeDropTxsEvent(chan<- core.DropTxsEvent) event.Subscription
+	SubscribeQueuedTxsEvent(chan<- *types.Transaction) event.Subscription
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/les/dropped_tx_subscription.go
+++ b/les/dropped_tx_subscription.go
@@ -10,6 +10,7 @@ package les
 import (
 	"errors"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
 
@@ -20,6 +21,10 @@ func (s *unimplementedSubscription) Err() <-chan error {
 	ch := make(chan error, 1)
 	ch <- errors.New("Subscription type not implemented")
 	return ch
+}
+
+func (b *LesApiBackend) SubscribeQueuedTxsEvent(ch chan<- *types.Transaction) event.Subscription {
+	return &unimplementedSubscription{}
 }
 
 func (b *LesApiBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {


### PR DESCRIPTION
Adds a newQueuedTransactionsWithPeers feed, just like newPendingTransactionsWithPeers, but for transactions that are queued instead of pending.

Note that the way Geth normally operates, transactions are queued, then evaluated to see which queued transactions should be pending. We set aside newly queued transactions to be sent *after* the pending transaction evaluation, then send any remaining queued transactions. This avoids having lots of duplicates between the queued feed and pending feed, but adds a small delay before notifications for queued transactions are sent.