### PR TITLE
Cache revert reasons by transaction and block hash

### DIFF
--- a/core/revert_cache.go
+++ b/core/revert_cache.go
@@ -10,18 +10,24 @@ var (
   revertCache *lru.Cache
 )
 
-func CacheRevertReason(h common.Hash, reason []byte) {
+func CacheRevertReason(h, blockHash common.Hash, reason []byte) {
   if revertCache == nil { revertCache, _ = lru.New(10000) }
   if reason != nil {
+    key := [64]byte{}
+    copy(key[:32], blockHash[:])
+    copy(key[32:], h[:])
     if reasonString, err := abi.UnpackRevert(reason); err == nil {
-      revertCache.Add(h, reasonString)
+      revertCache.Add(key, reasonString)
     }
   }
 }
 
-func GetRevertReason(h common.Hash) (string, bool) {
+func GetRevertReason(h, blockHash common.Hash) (string, bool) {
   if revertCache == nil { revertCache, _ = lru.New(10000) }
-  if v, ok := revertCache.Get(h); ok {
+  key := [64]byte{}
+  copy(key[:32], blockHash[:])
+  copy(key[32:], h[:])
+  if v, ok := revertCache.Get(key); ok {
     return v.(string), true
   }
   return "", false

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -104,7 +104,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	}
 
 	if revert := result.Revert(); revert != nil {
-		CacheRevertReason(tx.Hash(), revert)
+		CacheRevertReason(tx.Hash(), blockHash, revert)
 	}
 
 	// Update the state with pending changes.

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -208,7 +208,7 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 					if receipt.ContractAddress != (common.Address{}) {
 						fields["contractAddress"] = receipt.ContractAddress
 					}
-					if reason, ok := core.GetRevertReason(receipt.TxHash); ok {
+					if reason, ok := core.GetRevertReason(receipt.TxHash, hash); ok {
 						fields["revertReason"] = reason
 					}
 					marshalReceipts[receipt.TxHash] = fields


### PR DESCRIPTION
Hypothetically, if a transaction reverted in one version of a block
and succeeded in reorged versions of the block, the successful transaction
could show up with the revert reason. Caching on both the block hash
and transaction hash prevents this.