### PR TITLE
Better revert handling

### DIFF
--- a/core/revert_cache.go
+++ b/core/revert_cache.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+  "fmt"
   "github.com/ethereum/go-ethereum/common"
   "github.com/ethereum/go-ethereum/accounts/abi"
   lru "github.com/hashicorp/golang-lru"
@@ -18,6 +19,8 @@ func CacheRevertReason(h, blockHash common.Hash, reason []byte) {
     copy(key[32:], h[:])
     if reasonString, err := abi.UnpackRevert(reason); err == nil {
       revertCache.Add(key, reasonString)
+    } else {
+      revertCache.Add(key, fmt.Sprintf("%#x", reason))
     }
   }
 }

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -200,6 +200,7 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 						"contractAddress":   nil,
 						"logs":              receipt.Logs,
 						"logsBloom":         receipt.Bloom,
+						"status":            hexutil.Uint64(receipt.Status),
 					}
 					if receipt.Logs == nil {
 						fields["logs"] = [][]*types.Log{}


### PR DESCRIPTION
This adds "receipt.status" to the receipt data so that we can always
identify failed transactions even if they lack a revert reason.

It will also provide a hex encoded revert reason if the revert reason
cannot be ABI decoded.