### PR TITLE
Add trace results to NewFullBlocksWithPeers feed

### DIFF
--- a/core/revert_cache.go
+++ b/core/revert_cache.go
@@ -9,6 +9,7 @@ import (
 
 var (
   revertCache *lru.Cache
+  traceCache *lru.Cache
 )
 
 func CacheRevertReason(h, blockHash common.Hash, reason []byte) {
@@ -34,4 +35,19 @@ func GetRevertReason(h, blockHash common.Hash) (string, bool) {
     return v.(string), true
   }
   return "", false
+}
+func CacheTrace(h, blockHash common.Hash, traceResult interface{}) {
+  if traceCache == nil { traceCache, _ = lru.New(10000) }
+  key := [64]byte{}
+  copy(key[:32], blockHash[:])
+  copy(key[32:], h[:])
+	traceCache.Add(key, traceResult)
+}
+
+func GetTrace(h, blockHash common.Hash) (interface{}, bool) {
+  if traceCache == nil { traceCache, _ = lru.New(10000) }
+  key := [64]byte{}
+  copy(key[:32], blockHash[:])
+  copy(key[32:], h[:])
+	return traceCache.Get(key)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -27,7 +27,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/tracers/custom"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -71,6 +73,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		misc.ApplyDAOHardFork(statedb)
 	}
 	blockContext := NewEVMBlockContext(header, p.bc, nil)
+	oldDebug, oldTracer := cfg.Debug, cfg.Tracer
+	defer func() { cfg.Debug, cfg.Tracer = oldDebug, oldTracer }()
+	tracer := custom.NewCallTracer(statedb)
+	cfg.Debug = true
+	cfg.Tracer = tracer
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
@@ -85,6 +92,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		}
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
+		if result, err := tracer.GetResult(); err == nil {
+			CacheTrace(tx.Hash(), blockHash, result)
+		} else {
+			log.Warn("Failed to get result from racer", "block", blockHash, "num", blockNumber, "tx", tx.Hash())
+		}
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions(), block.Uncles())

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -212,6 +212,9 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 					if reason, ok := core.GetRevertReason(receipt.TxHash, hash); ok {
 						fields["revertReason"] = reason
 					}
+					if trace, ok := core.GetTrace(receipt.TxHash, hash); ok {
+						fields["callTrace"] = trace
+					}
 					marshalReceipts[receipt.TxHash] = fields
 				}
 				marshalBlock["receipts"] = marshalReceipts

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/eth/tracers/custom"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -793,7 +794,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			}
 		}
 		if *config.Tracer == "goCallTracer" {
-			tracer = NewCallTracer(statedb)
+			tracer = custom.NewCallTracer(statedb)
 		} else {
 			// Constuct the JavaScript tracer to execute with
 			if tracer, err = New(*config.Tracer, txctx); err != nil {
@@ -842,7 +843,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			StructLogs:  ethapi.FormatLogs(tracer.StructLogs()),
 		}, nil
 
-	case TracerResult:
+	case custom.TracerResult:
 		return tracer.GetResult()
 
 	case *Tracer:

--- a/eth/tracers/custom/call_tracer.go
+++ b/eth/tracers/custom/call_tracer.go
@@ -1,4 +1,4 @@
-package tracers
+package custom
 
 import (
 	"fmt"


### PR DESCRIPTION
This commit runs the Go Call Tracer during the block import phase, making those results available to the NewFullBlocksWithPeers feed.

The trace results are included with the transaction receipts. Even transactions which are simple ETH transfers will have a trace included.

The Go Call Tracer had to be moved from the core/tracers/ package to core/tracers/custom/ to avoid import loops, but its functionality has not changed.