### PR TITLE
Catch panics in traces

### DIFF
--- a/eth/tracers/call_tracer.go
+++ b/eth/tracers/call_tracer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 
-	// "github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/log"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -94,6 +94,12 @@ func (tracer *CallTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas
 	//   c.GasUsed = c.Gas - gas
 	//   tracer.callStack = tracer.callStack[:tracer.i()]
 	// }
+	defer func() {
+		if r := recover(); r != nil {
+			tracer.callStack[tracer.i()].Error = "internal failure"
+			log.Warn("Panic during trace. Recovered.", "err", r)
+		}
+	}()
 	if op == vm.CREATE || op == vm.CREATE2 {
 		inOff := scope.Stack.Back(1).Uint64()
 		inLen := scope.Stack.Back(2).Uint64()


### PR DESCRIPTION
The tracer generally assumes well formed opcodes. When there are not
enough items on the stack for a given opcode, it panics, causing Geth
to crash.

This catches those panics and notes it on the call stack to avoid
crashes while informing the user of the issue.