### PR TITLE
Use buffered channels, do better cleanup

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1941,6 +1941,7 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			msg = "Large chain reorg detected"
 			logFn = log.Warn
 		}
+		sendReorg(commonBlock, oldChain, newChain)
 		logFn(msg, "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
 		blockReorgAddMeter.Mark(int64(len(newChain)))

--- a/core/revert_cache.go
+++ b/core/revert_cache.go
@@ -3,12 +3,16 @@ package core
 import (
   "fmt"
   "github.com/ethereum/go-ethereum/common"
+  "github.com/ethereum/go-ethereum/common/hexutil"
+  "github.com/ethereum/go-ethereum/core/types"
+  "github.com/ethereum/go-ethereum/event"
   "github.com/ethereum/go-ethereum/accounts/abi"
   lru "github.com/hashicorp/golang-lru"
 )
 
 var (
   revertCache *lru.Cache
+  reorgFeed event.Feed
 )
 
 func CacheRevertReason(h, blockHash common.Hash, reason []byte) {
@@ -34,4 +38,30 @@ func GetRevertReason(h, blockHash common.Hash) (string, bool) {
     return v.(string), true
   }
   return "", false
+}
+type Reorg struct {
+	Common  common.Hash    `json:"common"`
+	Number  hexutil.Uint64 `json:"number"`
+	Removed []common.Hash  `json:"removed"`
+	Added   []common.Hash  `json:"added"`
+}
+
+func sendReorg(commonAncestor *types.Block, removed, added types.Blocks) {
+	reorg := &Reorg{
+		Common: commonAncestor.Hash(),
+		Number: hexutil.Uint64(commonAncestor.NumberU64()),
+		Removed: make([]common.Hash, len(removed)),
+		Added: make([]common.Hash, len(added)),
+	}
+	for i, block := range removed {
+		reorg.Removed[i] = block.Hash()
+	}
+	for i, block := range added {
+		reorg.Added[i] = block.Hash()
+	}
+	reorgFeed.Send(reorg)
+}
+
+func SubscribeReorgs(ch chan<- *Reorg) event.Subscription {
+	return reorgFeed.Subscribe(ch)
 }

--- a/eth/filters/peers_api.go
+++ b/eth/filters/peers_api.go
@@ -134,7 +134,7 @@ func (api *PublicFilterAPI) NewHeadsWithPeers(ctx context.Context) (*rpc.Subscri
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		headers := make(chan *types.Header)
+		headers := make(chan *types.Header, 1024)
 		headersSub := api.events.SubscribeNewHeads(headers)
 
 		for {
@@ -173,13 +173,33 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		headers := make(chan *types.Header)
+		headers := make(chan *types.Header, 1024)
 		headersSub := api.events.SubscribeNewHeads(headers)
+		reorgs := make(chan *core.Reorg, 1024)
+		reorgSub := core.SubscribeReorgs(reorgs)
+		defer headersSub.Unsubscribe()
+		defer reorgSub.Unsubscribe()
 
 		for {
+			var hashes []common.Hash
 			select {
+			case r := <-reorgs:
+				// Reverse the added blocks in the reorgs, excluding the latest block
+				// as it will be emitted on the newHeads channels.
+				hashes = make([]common.Hash, 0, len(r.Added) - 1)
+				for i := len(r.Added) - 1; i > 0; i-- {
+					hashes = append(hashes, r.Added[i])
+				}
 			case h := <-headers:
-				hash := h.Hash()
+				hashes = []common.Hash{h.Hash()}
+			case <-rpcSub.Err():
+				return
+			case <-reorgSub.Err():
+				return
+			case <-notifier.Closed():
+				return
+			}
+			for _, hash := range hashes {
 				peerid, _ := blockPeerMap.Get(hash)
 
 				block, err := api.backend.BlockByHash(ctx, hash)
@@ -221,12 +241,6 @@ func (api *PublicFilterAPI) NewFullBlocksWithPeers(ctx context.Context) (*rpc.Su
 				peer, _ := peerIDMap.Load(peerid)
 				log.Debug("NewFullBlocksWithPeers", "hash", hash, "peer", peerid, "peer", peer)
 				notifier.Notify(rpcSub.ID, withPeer{Value: marshalBlock, Peer: peer, Time: time.Now().UnixNano(), P2PTime: p2pts} )
-			case <-rpcSub.Err():
-				headersSub.Unsubscribe()
-				return
-			case <-notifier.Closed():
-				headersSub.Unsubscribe()
-				return
 			}
 		}
 	}()
@@ -288,7 +302,7 @@ func (api *PublicFilterAPI) NewTransactionReceipts(ctx context.Context) (*rpc.Su
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		headers := make(chan *types.Header)
+		headers := make(chan *types.Header, 1024)
 		headersSub := api.events.SubscribeNewHeads(headers)
 
 		for {
@@ -303,6 +317,36 @@ func (api *PublicFilterAPI) NewTransactionReceipts(ctx context.Context) (*rpc.Su
 				return
 			case <-notifier.Closed():
 				headersSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+// ReorgFeed
+func (api *PublicFilterAPI) ReorgFeed(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		ch := make(chan *core.Reorg, 1024)
+		sub := core.SubscribeReorgs(ch)
+
+		for {
+			select {
+			case r := <-ch:
+				notifier.Notify(rpcSub.ID, r)
+			case <-rpcSub.Err():
+				sub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				sub.Unsubscribe()
 				return
 			}
 		}


### PR DESCRIPTION
This makes two fixes to protect against node lockups due to
feeds.

The first is to use buffered channels. Without a buffered channel,
the block producer must wait until the consumer has taken a block
before it can continue producing blocks. Generally this isn't an
issue, but it could cause an underperforming consumer to bring
everything else grinding to a hault.

The bigger underlying issue is that the NewFullBlocksWithPeers
implementation was only cleaning up 1 of 2 subscriptions, which
meant the other channel was sticking around despite no consumers.
Once the producer tries to send another message to it, it will block
indefinitely. Buffered channels would have merely delayed this
until the buffer filled up, but the eventual result would have been
the same (but buffered channels are still good practice to deal with
slow but still processing consumers).