### PR TITLE
Feature : Unsigned Txn Bundle Simulation

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers/custom"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -153,6 +153,51 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	return receipt, err
 }
 
+func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, *ExecutionResult, error) {
+	// Create a new context to be used in the EVM environment.
+	txContext := NewEVMTxContext(msg)
+	evm.Reset(txContext, statedb)
+
+	// Apply the transaction to the current state (included in the env).
+	result, err := ApplyMessage(evm, msg, gp)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Update the state with pending changes.
+	var root []byte
+	if config.IsByzantium(header.Number) {
+		statedb.Finalise(true)
+	} else {
+		root = statedb.IntermediateRoot(config.IsEIP158(header.Number)).Bytes()
+	}
+	*usedGas += result.UsedGas
+
+	// Create a new receipt for the transaction, storing the intermediate root and gas used
+	// by the tx.
+	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
+	if result.Failed() {
+		receipt.Status = types.ReceiptStatusFailed
+	} else {
+		receipt.Status = types.ReceiptStatusSuccessful
+	}
+	receipt.TxHash = tx.Hash()
+	receipt.GasUsed = result.UsedGas
+
+	// If the transaction created a contract, store the creation address in the receipt.
+	if msg.To() == nil {
+		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+	}
+
+	// Set the receipt logs and create the bloom filter.
+	receipt.Logs = statedb.GetLogs(tx.Hash(), header.Hash())
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+	receipt.BlockHash = header.Hash()
+	receipt.BlockNumber = header.Number
+	receipt.TransactionIndex = uint(statedb.TxIndex())
+	return receipt, result, err
+}
+
 // ApplyTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
@@ -166,4 +211,15 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
 	return applyTransaction(msg, config, bc, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
+}
+
+func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
+	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Create a new context to be used in the EVM environment
+	blockContext := NewEVMBlockContext(header, bc, author)
+	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
+	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers/custom"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -245,8 +246,11 @@ func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainCont
 	var (
 		tracer vm.EVMLogger
 	)
+
 	// Add tracer native go tracer, code from eth/tracers/api.go
-	tracer = custom.NewCallTracer(statedb)
+	//tracer = custom.NewCallTracer(statedb)
+
+	tracer = logger.NewStructLogger(nil)
 
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -164,6 +164,13 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 		return nil, nil, err
 	}
 
+	traceResult := result.Return()
+	returnVal := fmt.Sprintf("%x", traceResult)
+	fmt.Println(returnVal)
+
+	if err != nil {
+		return nil, nil, err
+	}
 	// Update the state with pending changes.
 	var root []byte
 	if config.IsByzantium(header.Number) {
@@ -221,8 +228,14 @@ func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, aut
 	if err != nil {
 		return nil, nil, err
 	}
+	var (
+		tracer vm.EVMLogger
+	)
+	// Add tracer native go tracer, code from eth/tracers/api.go
+	tracer = custom.NewCallTracer(statedb)
+
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
-	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
+	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -154,7 +154,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	return receipt, err
 }
 
-func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msgTx types.Message, usedGas *uint64, evm *vm.EVM, tracer *logger.StructLogger) (*types.Receipt, *ExecutionResult, error) {
+func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msgTx types.Message, usedGas *uint64, evm *vm.EVM, tracer *logger.StructLogger) (*types.Receipt, *ExecutionResult, []StructLogRes, error) {
 	// Create a new context to be used in the EVM environment.
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
@@ -162,15 +162,15 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 	// Apply the transaction to the current state (included in the env).
 	result, err := ApplyMessage(evm, msg, gp)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	traceResult := tracer.StructLogs()
+	traceResult := FormatLogs(tracer.StructLogs())
 	returnVal := fmt.Sprintf("%x", traceResult)
 	fmt.Println(returnVal)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Update the state with pending changes.
 	var root []byte
@@ -203,7 +203,7 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 	receipt.BlockHash = header.Hash()
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	return receipt, result, err
+	return receipt, result, traceResult, err
 }
 
 // ApplyTransaction attempts to apply a transaction to the given state database
@@ -241,7 +241,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 // 	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
 // }
 
-func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msg types.Message, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
+func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msg types.Message, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, []StructLogRes, error) {
 	// Main functionality needed now is passing in a tracer and making sure applyTransactionWithResult works
 	// var (
 	// 	tracer logger.NewStructLogger
@@ -256,4 +256,55 @@ func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainCont
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, msg, usedGas, vmenv, tracer)
+}
+
+// StructLogRes stores a structured log emitted by the EVM while replaying a
+// transaction in debug mode
+type StructLogRes struct {
+	Pc      uint64             `json:"pc"`
+	Op      string             `json:"op"`
+	Gas     uint64             `json:"gas"`
+	GasCost uint64             `json:"gasCost"`
+	Depth   int                `json:"depth"`
+	Error   string             `json:"error,omitempty"`
+	Stack   *[]string          `json:"stack,omitempty"`
+	Memory  *[]string          `json:"memory,omitempty"`
+	Storage *map[string]string `json:"storage,omitempty"`
+}
+
+// FormatLogs formats EVM returned structured logs for json output
+func FormatLogs(logs []logger.StructLog) []StructLogRes {
+	formatted := make([]StructLogRes, len(logs))
+	for index, trace := range logs {
+		formatted[index] = StructLogRes{
+			Pc:      trace.Pc,
+			Op:      trace.Op.String(),
+			Gas:     trace.Gas,
+			GasCost: trace.GasCost,
+			Depth:   trace.Depth,
+			Error:   trace.ErrorString(),
+		}
+		if trace.Stack != nil {
+			stack := make([]string, len(trace.Stack))
+			for i, stackValue := range trace.Stack {
+				stack[i] = stackValue.Hex()
+			}
+			formatted[index].Stack = &stack
+		}
+		if trace.Memory != nil {
+			memory := make([]string, 0, (len(trace.Memory)+31)/32)
+			for i := 0; i+32 <= len(trace.Memory); i += 32 {
+				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
+			}
+			formatted[index].Memory = &memory
+		}
+		if trace.Storage != nil {
+			storage := make(map[string]string)
+			for i, storageValue := range trace.Storage {
+				storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
+			}
+			formatted[index].Storage = &storage
+		}
+	}
+	return formatted
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -153,7 +153,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, bc ChainCon
 	return receipt, err
 }
 
-func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (*types.Receipt, *ExecutionResult, error) {
+func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msgTx types.Message, usedGas *uint64, evm *vm.EVM) (*types.Receipt, *ExecutionResult, error) {
 	// Create a new context to be used in the EVM environment.
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
@@ -182,22 +182,22 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 
 	// Create a new receipt for the transaction, storing the intermediate root and gas used
 	// by the tx.
-	receipt := &types.Receipt{Type: tx.Type(), PostState: root, CumulativeGasUsed: *usedGas}
+	receipt := &types.Receipt{Type: 0, PostState: root, CumulativeGasUsed: *usedGas}
 	if result.Failed() {
 		receipt.Status = types.ReceiptStatusFailed
 	} else {
 		receipt.Status = types.ReceiptStatusSuccessful
 	}
-	receipt.TxHash = tx.Hash()
+	// receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
 
 	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To() == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
-	}
+	// if msg.To() == nil {
+	// 	receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+	// }
 
 	// Set the receipt logs and create the bloom filter.
-	receipt.Logs = statedb.GetLogs(tx.Hash(), header.Hash())
+	// receipt.Logs = statedb.GetLogs(tx.Hash(), header.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	receipt.BlockHash = header.Hash()
 	receipt.BlockNumber = header.Number
@@ -222,12 +222,26 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 
 // ApplyTransactionWithResult attempts to apply a transaction to the given state database
 // and returns an intermediate state root to be used in conjunction with other transactions
-func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
-	// can we accept the other message type here?
-	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
-	if err != nil {
-		return nil, nil, err
-	}
+// func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
+// 	// can we accept the other message type here?
+// 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+// 	var (
+// 		tracer vm.EVMLogger
+// 	)
+// 	// Add tracer native go tracer, code from eth/tracers/api.go
+// 	tracer = custom.NewCallTracer(statedb)
+
+// 	// Create a new context to be used in the EVM environment
+// 	blockContext := NewEVMBlockContext(header, bc, author)
+// 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
+// 	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
+// }
+
+func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msg types.Message, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
+	// Main functionality needed now is passing in a tracer and making sure applyTransactionWithResult works
 	var (
 		tracer vm.EVMLogger
 	)
@@ -237,5 +251,5 @@ func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, aut
 	// Create a new context to be used in the EVM environment
 	blockContext := NewEVMBlockContext(header, bc, author)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
-	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
+	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, msg, usedGas, vmenv)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -154,8 +154,6 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 	}
 
 	traceResult := FormatLogs(tracer.StructLogs())
-	returnVal := fmt.Sprintf("%x", traceResult)
-	fmt.Println(returnVal)
 
 	if err != nil {
 		return nil, nil, nil, err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -184,8 +184,6 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 	// }
 
 	// Set the receipt logs and create the bloom filter.
-	// receipt.Logs = statedb.GetLogs(tx.Hash(), header.Hash())
-	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	receipt.BlockHash = header.Hash()
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(statedb.TxIndex())

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -27,9 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/eth/tracers/custom"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -211,35 +209,8 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	return applyTransaction(msg, config, bc, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
 }
 
-// ApplyTransactionWithResult attempts to apply a transaction to the given state database
-// and returns an intermediate state root to be used in conjunction with other transactions
-// func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
-// 	// can we accept the other message type here?
-// 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-// 	var (
-// 		tracer vm.EVMLogger
-// 	)
-// 	// Add tracer native go tracer, code from eth/tracers/api.go
-// 	tracer = custom.NewCallTracer(statedb)
-
-// 	// Create a new context to be used in the EVM environment
-// 	blockContext := NewEVMBlockContext(header, bc, author)
-// 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
-// 	return applyTransactionWithResult(msg, config, bc, author, gp, statedb, header, tx, usedGas, vmenv)
-// }
-
 func ApplyUnsignedTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, msg types.Message, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, []StructLogRes, error) {
-	// Main functionality needed now is passing in a tracer and making sure applyTransactionWithResult works
-	// var (
-	// 	tracer logger.NewStructLogger
-	// )
-
-	// Add tracer native go tracer, code from eth/tracers/api.go
-	//tracer = custom.NewCallTracer(statedb)
-
+	// Create struct logger to get JSON stack traces
 	tracer := logger.NewStructLogger(nil)
 
 	// Create a new context to be used in the EVM environment

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -213,7 +213,10 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	return applyTransaction(msg, config, bc, author, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
 }
 
+// ApplyTransactionWithResult attempts to apply a transaction to the given state database
+// and returns an intermediate state root to be used in conjunction with other transactions
 func ApplyTransactionWithResult(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *ExecutionResult, error) {
+	// can we accept the other message type here?
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
 	if err != nil {
 		return nil, nil, err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -395,7 +395,7 @@ func (pool *TxPool) loop() {
 						pool.removeTx(tx.Hash(), true)
 					}
 					pool.dropTxFeed.Send(DropTxsEvent{
-						Txs: list,
+						Txs:    list,
 						Reason: dropOld,
 					})
 					queuedEvictionMeter.Mark(int64(len(list)))
@@ -474,7 +474,7 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		}
 		pool.priced.Removed(len(drop))
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: drop,
+			Txs:    drop,
 			Reason: dropGasPriceUpdated,
 		})
 	}
@@ -728,7 +728,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			pool.removeTx(tx.Hash(), false)
 		}
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: drop,
+			Txs:    drop,
 			Reason: dropUnderpriced,
 		})
 	}
@@ -747,8 +747,8 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			pool.priced.Removed(1)
 			pendingReplaceMeter.Mark(1)
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs: []*types.Transaction{old},
-				Reason: dropReplaced,
+				Txs:         []*types.Transaction{old},
+				Reason:      dropReplaced,
 				Replacement: tx,
 			})
 		}
@@ -803,7 +803,7 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction, local boo
 		pool.priced.Removed(1)
 		queuedReplaceMeter.Mark(1)
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: []*types.Transaction{old},
+			Txs:    []*types.Transaction{old},
 			Reason: dropReplaced,
 		})
 	} else {
@@ -863,7 +863,7 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 		pool.priced.Removed(1)
 		pendingReplaceMeter.Mark(1)
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: []*types.Transaction{old},
+			Txs:    []*types.Transaction{old},
 			Reason: dropReplaced,
 		})
 	} else {
@@ -965,7 +965,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		}
 		if err != nil {
 			pool.rejectTxFeed.Send(RejectedTxEvent{
-				Tx: txs[nilSlot],
+				Tx:     txs[nilSlot],
 				Reason: err,
 			})
 		}
@@ -1065,7 +1065,7 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 			// Reduce the pending counter
 			pendingGauge.Dec(int64(1 + len(invalids)))
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs: invalids,
+				Txs:    invalids,
 				Reason: dropUnexecutable,
 			})
 			return
@@ -1375,7 +1375,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: forwards,
+			Txs:    forwards,
 			Reason: dropLowNonce,
 		})
 		// Drop all transactions that are too costly (low balance or out of gas)
@@ -1387,7 +1387,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: drops,
+			Txs:    drops,
 			Reason: dropUnpayable,
 		})
 
@@ -1413,7 +1413,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			}
 			queuedRateLimitMeter.Mark(int64(len(caps)))
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs: caps,
+				Txs:    caps,
 				Reason: dropAccountCap,
 			})
 		}
@@ -1481,7 +1481,7 @@ func (pool *TxPool) truncatePending() {
 						log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
 					}
 					pool.dropTxFeed.Send(DropTxsEvent{
-						Txs: caps,
+						Txs:    caps,
 						Reason: dropAccountCap,
 					})
 					pool.priced.Removed(len(caps))
@@ -1512,7 +1512,7 @@ func (pool *TxPool) truncatePending() {
 					log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
 				}
 				pool.dropTxFeed.Send(DropTxsEvent{
-					Txs: caps,
+					Txs:    caps,
 					Reason: dropAccountCap,
 				})
 				pool.priced.Removed(len(caps))
@@ -1560,7 +1560,7 @@ func (pool *TxPool) truncateQueue() {
 				pool.removeTx(tx.Hash(), true)
 			}
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs: txs,
+				Txs:    txs,
 				Reason: dropTruncating,
 			})
 			drop -= size
@@ -1574,7 +1574,7 @@ func (pool *TxPool) truncateQueue() {
 			drop--
 			queuedRateLimitMeter.Mark(1)
 			pool.dropTxFeed.Send(DropTxsEvent{
-				Txs: []*types.Transaction{txs[i]},
+				Txs:    []*types.Transaction{txs[i]},
 				Reason: dropTruncating,
 			})
 		}
@@ -1601,7 +1601,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: olds,
+			Txs:    olds,
 			Reason: dropLowNonce,
 		})
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
@@ -1612,7 +1612,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			pool.all.Remove(hash)
 		}
 		pool.dropTxFeed.Send(DropTxsEvent{
-			Txs: drops,
+			Txs:    drops,
 			Reason: dropUnpayable,
 		})
 		pool.priced.Removed(len(olds) + len(drops))

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -611,6 +611,7 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 		msg.gasPrice = math.BigMin(msg.gasPrice.Add(msg.gasTipCap, baseFee), msg.gasFeeCap)
 	}
 	var err error
+	// recover sender address
 	msg.from, err = Sender(s, tx)
 	return msg, err
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -292,7 +292,7 @@ func makeExtraData(extra []byte) []byte {
 // APIs return the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *Ethereum) APIs() []rpc.API {
-	apis := ethapi.GetAPIs(s.APIBackend)
+	apis := ethapi.GetAPIs(s.APIBackend, s.BlockChain())
 
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2356,7 +2356,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 		}
 
 		// bn : using our new unsigned func
-		receipt, result, err := core.ApplyUnsignedTransactionWithResult(s.b.ChainConfig(), s.chain, &coinbase, gp, state, header, msg, &header.GasUsed, vmconfig)
+		receipt, result, traceResult, err := core.ApplyUnsignedTransactionWithResult(s.b.ChainConfig(), s.chain, &coinbase, gp, state, header, msg, &header.GasUsed, vmconfig)
 		if err != nil {
 			// TODO : create better log here
 			return nil, fmt.Errorf("err: %w; txhash %s", err, tx.From)
@@ -2366,6 +2366,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 			"gasUsed":     receipt.GasUsed,
 			"fromAddress": tx.from(),
 			"toAddress":   tx.To,
+			"traceResult": traceResult,
 			// Add trace results here
 		}
 		if result.Err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -18,6 +18,8 @@ package ethapi
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -47,6 +49,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/tyler-smith/go-bip39"
+	"golang.org/x/crypto/sha3"
 )
 
 // PublicEthereumAPI provides an API to access Ethereum related information.
@@ -2082,4 +2085,436 @@ func toHexSlice(b [][]byte) []string {
 		r[i] = hexutil.Encode(b[i])
 	}
 	return r
+}
+
+// ---------------------------------------------------------------- FlashBots ----------------------------------------------------------------
+
+// PrivateTxBundleAPI offers an API for accepting bundled transactions
+type PrivateTxBundleAPI struct {
+	b Backend
+}
+
+// NewPrivateTxBundleAPI creates a new Tx Bundle API instance.
+func NewPrivateTxBundleAPI(b Backend) *PrivateTxBundleAPI {
+	return &PrivateTxBundleAPI{b}
+}
+
+// SendBundleArgs represents the arguments for a SendBundle call.
+type SendBundleArgs struct {
+	Txs               []hexutil.Bytes `json:"txs"`
+	BlockNumber       rpc.BlockNumber `json:"blockNumber"`
+	MinTimestamp      *uint64         `json:"minTimestamp"`
+	MaxTimestamp      *uint64         `json:"maxTimestamp"`
+	RevertingTxHashes []common.Hash   `json:"revertingTxHashes"`
+}
+
+// SendMegabundleArgs represents the arguments for a SendMegabundle call.
+type SendMegabundleArgs struct {
+	Txs               []hexutil.Bytes `json:"txs"`
+	BlockNumber       uint64          `json:"blockNumber"`
+	MinTimestamp      *uint64         `json:"minTimestamp"`
+	MaxTimestamp      *uint64         `json:"maxTimestamp"`
+	RevertingTxHashes []common.Hash   `json:"revertingTxHashes"`
+	RelaySignature    hexutil.Bytes   `json:"relaySignature"`
+}
+
+// UnsignedMegabundle is used for serialization and subsequent digital signing.
+type UnsignedMegabundle struct {
+	Txs               []hexutil.Bytes
+	BlockNumber       uint64
+	MinTimestamp      uint64
+	MaxTimestamp      uint64
+	RevertingTxHashes []common.Hash
+}
+
+// // SendBundle will add the signed transaction to the transaction pool.
+// // The sender is responsible for signing the transaction and using the correct nonce and ensuring validity
+// func (s *PrivateTxBundleAPI) SendBundle(ctx context.Context, args SendBundleArgs) error {
+// 	var txs types.Transactions
+// 	if len(args.Txs) == 0 {
+// 		return errors.New("bundle missing txs")
+// 	}
+// 	if args.BlockNumber == 0 {
+// 		return errors.New("bundle missing blockNumber")
+// 	}
+
+// 	for _, encodedTx := range args.Txs {
+// 		tx := new(types.Transaction)
+// 		if err := tx.UnmarshalBinary(encodedTx); err != nil {
+// 			return err
+// 		}
+// 		txs = append(txs, tx)
+// 	}
+
+// 	var minTimestamp, maxTimestamp uint64
+// 	if args.MinTimestamp != nil {
+// 		minTimestamp = *args.MinTimestamp
+// 	}
+// 	if args.MaxTimestamp != nil {
+// 		maxTimestamp = *args.MaxTimestamp
+// 	}
+
+// 	return s.b.SendBundle(ctx, txs, args.BlockNumber, minTimestamp, maxTimestamp, args.RevertingTxHashes)
+// }
+
+// // Recovers the Ethereum address of the trusted relay that signed the megabundle.
+// func RecoverRelayAddress(args SendMegabundleArgs) (common.Address, error) {
+// 	megabundle := UnsignedMegabundle{Txs: args.Txs, BlockNumber: args.BlockNumber, RevertingTxHashes: args.RevertingTxHashes}
+// 	if args.MinTimestamp != nil {
+// 		megabundle.MinTimestamp = *args.MinTimestamp
+// 	} else {
+// 		megabundle.MinTimestamp = 0
+// 	}
+// 	if args.MaxTimestamp != nil {
+// 		megabundle.MaxTimestamp = *args.MaxTimestamp
+// 	} else {
+// 		megabundle.MaxTimestamp = 0
+// 	}
+// 	rlpEncoding, _ := rlp.EncodeToBytes(megabundle)
+// 	signature := args.RelaySignature
+// 	signature[64] -= 27 // account for Ethereum V
+// 	recoveredPubkey, err := crypto.SigToPub(accounts.TextHash(rlpEncoding), args.RelaySignature)
+// 	if err != nil {
+// 		return common.Address{}, err
+// 	}
+// 	return crypto.PubkeyToAddress(*recoveredPubkey), nil
+// }
+
+// // SendMegabundle will add the signed megabundle to one of the workers for evaluation.
+// func (s *PrivateTxBundleAPI) SendMegabundle(ctx context.Context, args SendMegabundleArgs) error {
+// 	log.Info("Received a Megabundle request", "signature", args.RelaySignature)
+// 	var txs types.Transactions
+// 	if len(args.Txs) == 0 {
+// 		return errors.New("megabundle missing txs")
+// 	}
+// 	if args.BlockNumber == 0 {
+// 		return errors.New("megabundle missing blockNumber")
+// 	}
+// 	for _, encodedTx := range args.Txs {
+// 		tx := new(types.Transaction)
+// 		if err := tx.UnmarshalBinary(encodedTx); err != nil {
+// 			return err
+// 		}
+// 		txs = append(txs, tx)
+// 	}
+// 	var minTimestamp, maxTimestamp uint64
+// 	if args.MinTimestamp != nil {
+// 		minTimestamp = *args.MinTimestamp
+// 	}
+// 	if args.MaxTimestamp != nil {
+// 		maxTimestamp = *args.MaxTimestamp
+// 	}
+// 	relayAddr, err := RecoverRelayAddress(args)
+// 	log.Info("Megabundle", "relayAddr", relayAddr, "err", err)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return s.b.SendMegabundle(ctx, txs, rpc.BlockNumber(args.BlockNumber), minTimestamp, maxTimestamp, args.RevertingTxHashes, relayAddr)
+// }
+
+// BundleAPI offers an API for accepting bundled transactions
+type BundleAPI struct {
+	b     Backend
+	chain *core.BlockChain
+}
+
+// NewBundleAPI creates a new Tx Bundle API instance.
+func NewBundleAPI(b Backend, chain *core.BlockChain) *BundleAPI {
+	return &BundleAPI{b, chain}
+}
+
+// CallBundleArgs represents the arguments for a call.
+type CallBundleArgs struct {
+	Txs                    []hexutil.Bytes       `json:"txs"`
+	BlockNumber            rpc.BlockNumber       `json:"blockNumber"`
+	StateBlockNumberOrHash rpc.BlockNumberOrHash `json:"stateBlockNumber"`
+	Coinbase               *string               `json:"coinbase"`
+	Timestamp              *uint64               `json:"timestamp"`
+	Timeout                *int64                `json:"timeout"`
+	GasLimit               *uint64               `json:"gasLimit"`
+	Difficulty             *big.Int              `json:"difficulty"`
+	BaseFee                *big.Int              `json:"baseFee"`
+}
+
+// CallBundle will simulate a bundle of transactions at the top of a given block
+// number with the state of another (or the same) block. This can be used to
+// simulate future blocks with the current state, or it can be used to simulate
+// a past block.
+// The sender is responsible for signing the transactions and using the correct
+// nonce and ensuring validity
+func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[string]interface{}, error) {
+	if len(args.Txs) == 0 {
+		return nil, errors.New("bundle missing txs")
+	}
+	if args.BlockNumber == 0 {
+		return nil, errors.New("bundle missing blockNumber")
+	}
+
+	var txs types.Transactions
+
+	for _, encodedTx := range args.Txs {
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(encodedTx); err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
+
+	timeoutMilliSeconds := int64(5000)
+	if args.Timeout != nil {
+		timeoutMilliSeconds = *args.Timeout
+	}
+	timeout := time.Millisecond * time.Duration(timeoutMilliSeconds)
+	state, parent, err := s.b.StateAndHeaderByNumberOrHash(ctx, args.StateBlockNumberOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	blockNumber := big.NewInt(int64(args.BlockNumber))
+
+	timestamp := parent.Time + 1
+	if args.Timestamp != nil {
+		timestamp = *args.Timestamp
+	}
+	coinbase := parent.Coinbase
+	if args.Coinbase != nil {
+		coinbase = common.HexToAddress(*args.Coinbase)
+	}
+	difficulty := parent.Difficulty
+	if args.Difficulty != nil {
+		difficulty = args.Difficulty
+	}
+	gasLimit := parent.GasLimit
+	if args.GasLimit != nil {
+		gasLimit = *args.GasLimit
+	}
+	var baseFee *big.Int
+	if args.BaseFee != nil {
+		baseFee = args.BaseFee
+	} else if s.b.ChainConfig().IsLondon(big.NewInt(args.BlockNumber.Int64())) {
+		baseFee = misc.CalcBaseFee(s.b.ChainConfig(), parent)
+	}
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     blockNumber,
+		GasLimit:   gasLimit,
+		Time:       timestamp,
+		Difficulty: difficulty,
+		Coinbase:   coinbase,
+		BaseFee:    baseFee,
+	}
+
+	// Setup context so it may be cancelled the call has completed
+	// or, in case of unmetered gas, setup a context with a timeout.
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	// Make sure the context is cancelled when the call has completed
+	// this makes sure resources are cleaned up.
+	defer cancel()
+
+	vmconfig := vm.Config{}
+
+	// Setup the gas pool (also for unmetered requests)
+	// and apply the message.
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+
+	results := []map[string]interface{}{}
+	coinbaseBalanceBefore := state.GetBalance(coinbase)
+
+	bundleHash := sha3.NewLegacyKeccak256()
+	signer := types.MakeSigner(s.b.ChainConfig(), blockNumber)
+	var totalGasUsed uint64
+	gasFees := new(big.Int)
+	for i, tx := range txs {
+		coinbaseBalanceBeforeTx := state.GetBalance(coinbase)
+		state.Prepare(tx.Hash(), i)
+
+		receipt, result, err := core.ApplyTransactionWithResult(s.b.ChainConfig(), s.chain, &coinbase, gp, state, header, tx, &header.GasUsed, vmconfig)
+		if err != nil {
+			return nil, fmt.Errorf("err: %w; txhash %s", err, tx.Hash())
+		}
+
+		txHash := tx.Hash().String()
+		from, err := types.Sender(signer, tx)
+		if err != nil {
+			return nil, fmt.Errorf("err: %w; txhash %s", err, tx.Hash())
+		}
+		to := "0x"
+		if tx.To() != nil {
+			to = tx.To().String()
+		}
+		jsonResult := map[string]interface{}{
+			"txHash":      txHash,
+			"gasUsed":     receipt.GasUsed,
+			"fromAddress": from.String(),
+			"toAddress":   to,
+		}
+		totalGasUsed += receipt.GasUsed
+		gasPrice, err := tx.EffectiveGasTip(header.BaseFee)
+		if err != nil {
+			return nil, fmt.Errorf("err: %w; txhash %s", err, tx.Hash())
+		}
+		gasFeesTx := new(big.Int).Mul(big.NewInt(int64(receipt.GasUsed)), gasPrice)
+		gasFees.Add(gasFees, gasFeesTx)
+		bundleHash.Write(tx.Hash().Bytes())
+		if result.Err != nil {
+			jsonResult["error"] = result.Err.Error()
+			revert := result.Revert()
+			if len(revert) > 0 {
+				jsonResult["revert"] = string(revert)
+			}
+		} else {
+			dst := make([]byte, hex.EncodedLen(len(result.Return())))
+			hex.Encode(dst, result.Return())
+			jsonResult["value"] = "0x" + string(dst)
+		}
+		coinbaseDiffTx := new(big.Int).Sub(state.GetBalance(coinbase), coinbaseBalanceBeforeTx)
+		jsonResult["coinbaseDiff"] = coinbaseDiffTx.String()
+		jsonResult["gasFees"] = gasFeesTx.String()
+		jsonResult["ethSentToCoinbase"] = new(big.Int).Sub(coinbaseDiffTx, gasFeesTx).String()
+		jsonResult["gasPrice"] = new(big.Int).Div(coinbaseDiffTx, big.NewInt(int64(receipt.GasUsed))).String()
+		jsonResult["gasUsed"] = receipt.GasUsed
+		results = append(results, jsonResult)
+	}
+
+	ret := map[string]interface{}{}
+	ret["results"] = results
+	coinbaseDiff := new(big.Int).Sub(state.GetBalance(coinbase), coinbaseBalanceBefore)
+	ret["coinbaseDiff"] = coinbaseDiff.String()
+	ret["gasFees"] = gasFees.String()
+	ret["ethSentToCoinbase"] = new(big.Int).Sub(coinbaseDiff, gasFees).String()
+	ret["bundleGasPrice"] = new(big.Int).Div(coinbaseDiff, big.NewInt(int64(totalGasUsed))).String()
+	ret["totalGasUsed"] = totalGasUsed
+	ret["stateBlockNumber"] = parent.Number.Int64()
+
+	ret["bundleHash"] = "0x" + common.Bytes2Hex(bundleHash.Sum(nil))
+	return ret, nil
+}
+
+// EstimateGasBundleArgs represents the arguments for a call
+type EstimateGasBundleArgs struct {
+	Txs                    []TransactionArgs     `json:"txs"`
+	BlockNumber            rpc.BlockNumber       `json:"blockNumber"`
+	StateBlockNumberOrHash rpc.BlockNumberOrHash `json:"stateBlockNumber"`
+	Coinbase               *string               `json:"coinbase"`
+	Timestamp              *uint64               `json:"timestamp"`
+	Timeout                *int64                `json:"timeout"`
+}
+
+func (s *BundleAPI) EstimateGasBundle(ctx context.Context, args EstimateGasBundleArgs) (map[string]interface{}, error) {
+	if len(args.Txs) == 0 {
+		return nil, errors.New("bundle missing txs")
+	}
+	if args.BlockNumber == 0 {
+		return nil, errors.New("bundle missing blockNumber")
+	}
+
+	timeoutMS := int64(5000)
+	if args.Timeout != nil {
+		timeoutMS = *args.Timeout
+	}
+	timeout := time.Millisecond * time.Duration(timeoutMS)
+
+	state, parent, err := s.b.StateAndHeaderByNumberOrHash(ctx, args.StateBlockNumberOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	blockNumber := big.NewInt(int64(args.BlockNumber))
+	timestamp := parent.Time + 1
+	if args.Timestamp != nil {
+		timestamp = *args.Timestamp
+	}
+	coinbase := parent.Coinbase
+	if args.Coinbase != nil {
+		coinbase = common.HexToAddress(*args.Coinbase)
+	}
+
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     blockNumber,
+		GasLimit:   parent.GasLimit,
+		Time:       timestamp,
+		Difficulty: parent.Difficulty,
+		Coinbase:   coinbase,
+		BaseFee:    parent.BaseFee,
+	}
+
+	// Setup context so it may be cancelled when the call
+	// has completed or, in case of unmetered gas, setup
+	// a context with a timeout
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+
+	// Make sure the context is cancelled when the call has completed
+	// This makes sure resources are cleaned up
+	defer cancel()
+
+	// RPC Call gas cap
+	globalGasCap := s.b.RPCGasCap()
+
+	// Results
+	results := []map[string]interface{}{}
+
+	// Copy the original db so we don't modify it
+	statedb := state.Copy()
+
+	// Gas pool
+	gp := new(core.GasPool).AddGas(math.MaxUint64)
+
+	// Block context
+	blockContext := core.NewEVMBlockContext(header, s.chain, &coinbase)
+
+	// Feed each of the transactions into the VM ctx
+	// And try and estimate the gas used
+	for i, txArgs := range args.Txs {
+		// Since its a txCall we'll just prepare the
+		// state with a random hash
+		var randomHash common.Hash
+		rand.Read(randomHash[:])
+
+		// New random hash since its a call
+		statedb.Prepare(randomHash, i)
+
+		// Convert tx args to msg to apply state transition
+		msg, err := txArgs.ToMessage(globalGasCap, header.BaseFee)
+		if err != nil {
+			return nil, err
+		}
+
+		// Prepare the hashes
+		txContext := core.NewEVMTxContext(msg)
+
+		// Get EVM Environment
+		vmenv := vm.NewEVM(blockContext, txContext, statedb, s.b.ChainConfig(), vm.Config{NoBaseFee: true})
+
+		// Apply state transition
+		result, err := core.ApplyMessage(vmenv, msg, gp)
+		if err != nil {
+			return nil, err
+		}
+
+		// Modifications are committed to the state
+		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
+		statedb.Finalise(vmenv.ChainConfig().IsEIP158(blockNumber))
+
+		// Append result
+		jsonResult := map[string]interface{}{
+			"gasUsed": result.UsedGas,
+		}
+		results = append(results, jsonResult)
+	}
+
+	// Return results
+	ret := map[string]interface{}{}
+	ret["results"] = results
+
+	return ret, nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2389,7 +2389,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 	ret["coinbaseDiff"] = coinbaseDiff.String()
 	ret["gasFees"] = gasFees.String()
 	ret["ethSentToCoinbase"] = new(big.Int).Sub(coinbaseDiff, gasFees).String()
-	ret["bundleGasPrice"] = new(big.Int).Div(coinbaseDiff, big.NewInt(int64(totalGasUsed))).String()
+	//ret["bundleGasPrice"] = new(big.Int).Div(coinbaseDiff, big.NewInt(int64(totalGasUsed))).String()
 	ret["totalGasUsed"] = totalGasUsed
 	ret["stateBlockNumber"] = parent.Number.Int64()
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2245,10 +2245,11 @@ type CallBundleArgs struct {
 // nonce and ensuring validity
 func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[string]interface{}, error) {
 	// ******** Unsigned Txn Attempt
+	log.Error("here1")
 	if len(args.UnsignedTxs) == 0 {
 		return nil, errors.New("bundle missing unsigned txs")
 	}
-
+	log.Error("here2")
 	// ******** Unsigned Txn Attempt
 	// if len(args.Txs) == 0 {
 	// 	return nil, errors.New("bundle missing txs")
@@ -2256,7 +2257,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 	if args.BlockNumber == 0 {
 		return nil, errors.New("bundle missing blockNumber")
 	}
-
+	log.Error("here1")
 	// var txs types.Transactions
 
 	// for _, encodedTx := range args.Txs {
@@ -2267,7 +2268,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 	// 	txs = append(txs, tx)
 	// }
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
-
+	log.Error("here1")
 	timeoutMilliSeconds := int64(5000)
 	if args.Timeout != nil {
 		timeoutMilliSeconds = *args.Timeout

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2086,7 +2086,7 @@ func toHexSlice(b [][]byte) []string {
 	return r
 }
 
-// ---------------------------------------------------------------- FlashBots ----------------------------------------------------------------
+// ---------------------------------------------------------------- FlashBots inspired code ----------------------------------------------------------------
 
 // PrivateTxBundleAPI offers an API for accepting bundled transactions
 type PrivateTxBundleAPI struct {
@@ -2180,10 +2180,6 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 		Coinbase:   coinbase,
 		BaseFee:    baseFee,
 	}
-	if header != nil {
-		log.Error("here4")
-	}
-
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.
 	var cancel context.CancelFunc

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2364,7 +2364,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 		// TODO : Add gas features back
 		jsonResult := map[string]interface{}{
 			"gasUsed":     receipt.GasUsed,
-			"fromAddress": tx.from,
+			"fromAddress": tx.from(),
 			"toAddress":   tx.To,
 			// Add trace results here
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2369,6 +2369,7 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 			"traceResult": traceResult,
 			// Add trace results here
 		}
+		totalGasUsed += receipt.GasUsed
 		if result.Err != nil {
 			jsonResult["error"] = result.Err.Error()
 			revert := result.Revert()
@@ -2386,15 +2387,9 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 
 	ret := map[string]interface{}{}
 	ret["results"] = results
-	coinbaseDiff := new(big.Int).Sub(state.GetBalance(coinbase), coinbaseBalanceBefore)
-	ret["coinbaseDiff"] = coinbaseDiff.String()
 	ret["gasFees"] = gasFees.String()
-	ret["ethSentToCoinbase"] = new(big.Int).Sub(coinbaseDiff, gasFees).String()
-	//ret["bundleGasPrice"] = new(big.Int).Div(coinbaseDiff, big.NewInt(int64(totalGasUsed))).String()
-	ret["totalGasUsed"] = totalGasUsed
-	ret["stateBlockNumber"] = parent.Number.Int64()
-
-	// ret["bundleHash"] = "0x" + common.Bytes2Hex(bundleHash.Sum(nil))
+	ret["gasUsed"] = totalGasUsed
+	ret["blockNumber"] = parent.Number.Int64()
 
 	ret["args"] = header
 	return ret, nil

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -97,7 +97,7 @@ type Backend interface {
 	Engine() consensus.Engine
 }
 
-func GetAPIs(apiBackend Backend) []rpc.API {
+func GetAPIs(apiBackend Backend, chain *core.BlockChain) []rpc.API {
 	nonceLock := new(AddrLocker)
 	return []rpc.API{
 		{
@@ -139,6 +139,11 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Version:   "1.0",
 			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
 			Public:    false,
+		}, {
+			Namespace: "eth",
+			Version:   "1.0",
+			Service:   NewBundleAPI(apiBackend, chain),
+			Public:    true,
 		},
 	}
 }

--- a/les/client.go
+++ b/les/client.go
@@ -282,7 +282,7 @@ func (s *LightDummyAPI) Mining() bool {
 // APIs returns the collection of RPC services the ethereum package offers.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (s *LightEthereum) APIs() []rpc.API {
-	apis := ethapi.GetAPIs(s.ApiBackend)
+	apis := ethapi.GetAPIs(s.ApiBackend, nil)
 	apis = append(apis, s.engine.APIs(s.BlockChain().HeaderChain())...)
 	return append(apis, []rpc.API{
 		{


### PR DESCRIPTION
- This PR adds support from eth_callBundle RPC which was originally forked from flashbots MEV-GETH.
- Addition on top of mev-geth call bundle RPC are support for unsigned txns, payload modifications, and the addition of the geth internal struct logger to output JSON stack traces of EVM calls