### PR TITLE
Fix | Old tracer error returning

### DIFF
--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -71,25 +71,8 @@ func (tracer *CallTracer) i() int {
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
-
 	res, err := json.Marshal(tracer.callStack[0])
-	if len(tracer.callStack) != 1 {
-		fmt.Println("DEBUG | callStack length != 1")
-		fmt.Println("DEBUG | reason: ", tracer.reason)
-		res1, _ := json.Marshal(tracer.callStack)
-		fmt.Println("DEBUG | callstack of failed: ", string(res1))
-		fmt.Println("DEBUG | err: ", fmt.Sprintf("%v", err))
-		// return nil, errors.New("incorrect number of top-level calls")
-	}
-
-	// // DANGER CODE, will spam, don't run for long heehee
-	// res1, _ := json.Marshal(tracer.callStack)
-	// fmt.Println("DEBUG | res1: ", string(res1))
-
-	if err != nil {
-		return nil, err
-	}
-	return json.RawMessage(res), tracer.reason
+	return json.RawMessage(res), err
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.

--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -75,8 +75,8 @@ func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
 	res, err := json.Marshal(tracer.callStack[0])
 	if len(tracer.callStack) != 1 {
 		fmt.Println("DEBUG | callStack length != 1")
-		fmt.Println("DEBUG | res: ", tracer.reason)
-		fmt.Println("DEBUG | res: ", json.RawMessage(res))
+		fmt.Println("DEBUG | reson: ", tracer.reason)
+		fmt.Println("DEBUG | res: ", string(res))
 		fmt.Println("DEBUG | err: ", fmt.Sprintf("%v", err))
 		// return nil, errors.New("incorrect number of top-level calls")
 	}

--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -2,7 +2,6 @@ package native
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -73,7 +72,8 @@ func (tracer *CallTracer) i() int {
 // error arising from the encoding or forceful termination (via `Stop`).
 func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
 	if len(tracer.callStack) != 1 {
-		return nil, errors.New("incorrect number of top-level calls")
+		fmt.Println("DEBUG | callStack length != 1")
+		// return nil, errors.New("incorrect number of top-level calls")
 	}
 	res, err := json.Marshal(tracer.callStack[0])
 	if err != nil {

--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -75,11 +75,16 @@ func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
 	res, err := json.Marshal(tracer.callStack[0])
 	if len(tracer.callStack) != 1 {
 		fmt.Println("DEBUG | callStack length != 1")
-		fmt.Println("DEBUG | reson: ", tracer.reason)
+		fmt.Println("DEBUG | reason: ", tracer.reason)
 		fmt.Println("DEBUG | res: ", string(res))
 		fmt.Println("DEBUG | err: ", fmt.Sprintf("%v", err))
 		// return nil, errors.New("incorrect number of top-level calls")
 	}
+
+	// DANGER CODE, will spam, don't run for long heehee
+	res1, _ := json.Marshal(tracer.callStack)
+	fmt.Println("DEBUG | res1: ", string(res1))
+
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -71,11 +71,15 @@ func (tracer *CallTracer) i() int {
 // GetResult returns the json-encoded nested list of call traces, and any
 // error arising from the encoding or forceful termination (via `Stop`).
 func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
+
+	res, err := json.Marshal(tracer.callStack[0])
 	if len(tracer.callStack) != 1 {
 		fmt.Println("DEBUG | callStack length != 1")
+		fmt.Println("DEBUG | res: ", tracer.reason)
+		fmt.Println("DEBUG | res: ", json.RawMessage(res))
+		fmt.Println("DEBUG | err: ", fmt.Sprintf("%v", err))
 		// return nil, errors.New("incorrect number of top-level calls")
 	}
-	res, err := json.Marshal(tracer.callStack[0])
 	if err != nil {
 		return nil, err
 	}

--- a/eth/tracers/native/goCallTracer.go
+++ b/eth/tracers/native/goCallTracer.go
@@ -76,14 +76,15 @@ func (tracer *CallTracer) GetResult() (json.RawMessage, error) {
 	if len(tracer.callStack) != 1 {
 		fmt.Println("DEBUG | callStack length != 1")
 		fmt.Println("DEBUG | reason: ", tracer.reason)
-		fmt.Println("DEBUG | res: ", string(res))
+		res1, _ := json.Marshal(tracer.callStack)
+		fmt.Println("DEBUG | callstack of failed: ", string(res1))
 		fmt.Println("DEBUG | err: ", fmt.Sprintf("%v", err))
 		// return nil, errors.New("incorrect number of top-level calls")
 	}
 
-	// DANGER CODE, will spam, don't run for long heehee
-	res1, _ := json.Marshal(tracer.callStack)
-	fmt.Println("DEBUG | res1: ", string(res1))
+	// // DANGER CODE, will spam, don't run for long heehee
+	// res1, _ := json.Marshal(tracer.callStack)
+	// fmt.Println("DEBUG | res1: ", string(res1))
 
 	if err != nil {
 		return nil, err

--- a/eth/tracers/native/txnOpCodeTracer.go
+++ b/eth/tracers/native/txnOpCodeTracer.go
@@ -2,7 +2,6 @@ package native
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -62,9 +61,15 @@ func newtxnOpCodeTracer(ctx *tracers.Context) tracers.Tracer {
 
 // GetResult returns an empty json object.
 func (t *txnOpCodeTracer) GetResult() (json.RawMessage, error) {
-	if len(t.callStack) != 1 {
-		return nil, errors.New("incorrect number of top-level calls")
-	}
+
+	// This block used to trip on subtraces being discovered, for this tracer we do not need this,
+	// however we would like to keep this here in a possible future where we do care about such cases.
+
+	// if len(t.callStack) != 1 {
+	// 	return nil, errors.New("incorrect number of top-level calls")
+	// }
+
+	// Only want the top level trace, all other indexes hold subtraces to which we do not particularly need
 	res, err := json.Marshal(t.callStack[0])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Returns old tracer to expected return values.
- This logic means we always return the top level trace and no subtraces, which we expect in our current system. 
- Handling will be added in Blocknative side code bases to handle the differences in returning subtraces vs not.