### PR TITLE
add bootnode binary build to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,10 @@ jobs:
           goarch: amd64
           project_path: ./cmd/geth
           binary_name: geth
+      - uses: wangyoucao577/go-release-action@v1.26
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: linux
+          goarch: amd64
+          project_path: ./cmd/bootnode
+          binary_name: bootnode


### PR DESCRIPTION
For the private testnet we need to run a bootnode so we need to build the bootnode cmd binary.

Release with this work included: https://github.com/blocknative/go-ethereum/releases/tag/v1.10.23-build-bootnode