### PR TITLE
BUGFIX: Finalize state between txs in callBundle.

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2354,6 +2354,11 @@ func (s *BundleAPI) CallBundle(ctx context.Context, args CallBundleArgs) (map[st
 			hex.Encode(dst, result.Return())
 			jsonResult["value"] = "0x" + string(dst)
 		}
+
+		// Modifications are committed to the state
+		// Only delete empty objects if EIP158/161 (a.k.a Spurious Dragon) is in effect
+		state.Finalise(s.chain.Config().IsEIP150(header.Number))
+
 		coinbaseDiffTx := new(big.Int).Sub(state.GetBalance(coinbase), coinbaseBalanceBeforeTx)
 		jsonResult["coinbaseDiff"] = coinbaseDiffTx.String()
 		jsonResult["gasFees"] = gasFeesTx.String()


### PR DESCRIPTION
This routine handles the details of the gas accounting for state-related operations, like rebates and operations that depend on existing state values when calculating gas cost. Without calling it, we incorrectly calculate transactions in bundles that come after a transaction that touches one of these facilities.

This can be tested with this script that bundles txs from the mempool and sends them to `callBundle` on both the prod auction gateway and a local tunnel to a sim node. Without the fix, it fails 99% of the time. With this fix, it succeeds 100% of the time. https://github.com/tyler-smith/bundles-go/blob/TS_testCallBundle/examples/testCallBundle/main.go