### PR TITLE
BUGFIX: Enable state finalization.

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -158,8 +158,7 @@ func applyTransactionWithResult(msg types.Message, config *params.ChainConfig, b
 	// Update the state with pending changes.
 	var root []byte
 	if config.IsByzantium(header.Number) {
-		// statedb.GetRefund()
-
+		statedb.Finalise(true)
 	} else {
 		root = statedb.IntermediateRoot(config.IsEIP158(header.Number)).Bytes()
 	}


### PR DESCRIPTION
Replaces PR #81 

This routine handles the details of the gas accounting for state-related operations, like rebates and operations that depend on existing state values when calculating gas cost. Without calling it, we incorrectly calculate transactions in bundles that come after a transaction that touches one of these facilities.

This can be tested with this script that bundles txs from the mempool and sends them to callBundle on both the prod auction gateway and a local tunnel to a sim node. Without the fix, it fails 99% of the time. With this fix, it succeeds 100% of the time. https://github.com/tyler-smith/bundles-go/blob/TS_testCallBundle/examples/testCallBundle/main.go

This change brings the code to be inline with mev-geth and other mev-geth forks.

