### PR TITLE
tweak: Use int nanoseconds instead of string for duration.

### DIFF
--- a/eth/tracers/blocknative/blocknative.go
+++ b/eth/tracers/blocknative/blocknative.go
@@ -30,7 +30,7 @@ type Trace struct {
 	CallFrame
 	BlockContext   *BlockContext             `json:"blockContext,omitempty"`
 	Logs           []CallLog                 `json:"logs,omitempty"`
-	Time           string                    `json:"time,omitempty"`
+	Time           int64                     `json:"time,omitempty"`
 	BalanceChanges decoder.NetBalanceChanges `json:"balanceChanges"`
 }
 

--- a/eth/tracers/blocknative/txnOpCodeTracer.go
+++ b/eth/tracers/blocknative/txnOpCodeTracer.go
@@ -2,7 +2,6 @@ package blocknative
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -154,8 +153,7 @@ func (t *txnOpCodeTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	}
 
 	// Add total time duration for this trace request
-	elapsedTime := time.Now().Sub(t.startTime)
-	t.trace.Time = fmt.Sprintf("%v", elapsedTime)
+	t.trace.Time = time.Now().Sub(t.startTime).Nanoseconds()
 }
 
 // CaptureState implements the EVMLogger interface to trace a single step of VM execution.

--- a/eth/tracers/internal/tracetest/txnOpCodeTracer_test.go
+++ b/eth/tracers/internal/tracetest/txnOpCodeTracer_test.go
@@ -265,8 +265,8 @@ func (a BalanceChangesByAssetAddress) Less(i, j int) bool {
 
 func tracesEqual(x, y *blocknative.Trace) bool {
 	// Clear out non-deterministic time
-	x.Time = ""
-	y.Time = ""
+	x.Time = 0
+	y.Time = 0
 
 	// Sort the balance changes because we don't care about the order of the
 	// breakdown.


### PR DESCRIPTION
Currently, the trace duration is reported in a human-oriented string format. To facilitate easy tracking of performance, we want to change this to an integer with a consistent time resolution.