### PR TITLE
Add test flags and clear cache between tests to fix deterministic failures.

### DIFF
--- a/eth/tracers/blocknative/tracer.go
+++ b/eth/tracers/blocknative/tracer.go
@@ -242,6 +242,12 @@ func finalizeCallFrame(call *CallFrame, output []byte, gasUsed uint64, err error
 	call.Output = bytesToHex(output)
 }
 
+// EmptyCache is for testing purposes. It clears the global cache so tests don't
+// interfere with each other.
+func EmptyCache() {
+	decoderCache = decoder.NewCaches()
+}
+
 //
 // Unused interface methods.
 //

--- a/eth/tracers/internal/tracetest/blocknative_test.go
+++ b/eth/tracers/internal/tracetest/blocknative_test.go
@@ -24,7 +24,10 @@ import (
 	"github.com/ethereum/go-ethereum/tests"
 )
 
-var testFileFlag = flag.String("file", "", "Name of the file to run the test for")
+var (
+	testFlagLogLevl = flag.String("loglevel", "info", "Log level to use")
+	testFlagFile    = flag.String("file", "", "Name of the file to run the test for")
+)
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -51,7 +54,7 @@ type blocknativeTracerTest struct {
 }
 
 func TestBlocknativeTracer(t *testing.T) {
-	log.Root().SetHandler(log.StreamHandler(os.Stdout, log.TerminalFormat(true)))
+	setLogging(t)
 
 	testsCases, err := loadTestTxs("blocknative")
 	if err != nil {
@@ -64,8 +67,8 @@ func TestBlocknativeTracer(t *testing.T) {
 	testsCases = append(testsCases, decodingTestsCases...)
 
 	for _, test := range testsCases {
-		if *testFileFlag != "" {
-			a := strings.ToLower(*testFileFlag)
+		if *testFlagFile != "" {
+			a := strings.ToLower(*testFlagFile)
 			b := strings.ToLower(test.name)
 			if a != b {
 				continue
@@ -166,6 +169,19 @@ func benchmarkBlocknativeTracer(b *testing.B, decode bool, dirPaths ...string) {
 		executeTestCase(test, b, false)
 
 	}
+}
+
+func setLogging(t testing.TB) {
+	logHandler := log.StreamHandler(os.Stdout, log.TerminalFormat(true))
+	level := log.LvlDebug
+	if *testFlagLogLevl != "" {
+		var err error
+		level, err = log.LvlFromString(*testFlagLogLevl)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	log.Root().SetHandler(log.LvlFilterHandler(level, logHandler))
 }
 
 func loadTestTxs(dirPath string) ([]*blocknativeTracerTest, error) {

--- a/eth/tracers/internal/tracetest/blocknative_test.go
+++ b/eth/tracers/internal/tracetest/blocknative_test.go
@@ -280,15 +280,14 @@ func executeTestCase(test *blocknativeTracerTest, t testing.TB, checkResult bool
 
 	if checkResult && !tracesEqual(ret, test.Result) {
 		// Below are prints to show differences if we fail, can always just check against the specific test json files too!
-		fmt.Println("Trace return: ")
+		fmt.Println("Got Trace:")
 		x, _ := json.Marshal(ret)
-		// //x, _ := json.MarshalIndent(ret, "", "	")
-		// y, _ := json.Marshal(test.Result)
 		fmt.Println(string(x))
-		fmt.Println("test.Result")
+
+		// fmt.Println("Expected Trace:")
+		// y, _ := json.Marshal(test.Result)
 		// fmt.Println(string(y))
 		t.Fatal("traces mismatch")
-		// t.Fatalf("trace mismatch: \nhave %+v\nwant %+v", ret, test.Result)
 	}
 }
 

--- a/eth/tracers/internal/tracetest/blocknative_test.go
+++ b/eth/tracers/internal/tracetest/blocknative_test.go
@@ -264,6 +264,8 @@ func loadTestTxs(dirPath string) ([]*blocknativeTracerTest, error) {
 }
 
 func executeTestCase(test *blocknativeTracerTest, t testing.TB, checkResult bool) {
+	blocknative.EmptyCache()
+
 	st := core.NewStateTransition(test.evm, test.msg, new(core.GasPool).AddGas(test.tx.Gas()))
 	if _, err := st.TransitionDb(); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)

--- a/eth/tracers/internal/tracetest/blocknative_test.go
+++ b/eth/tracers/internal/tracetest/blocknative_test.go
@@ -2,6 +2,7 @@ package tracetest
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"math/big"
 	"os"
@@ -22,6 +23,13 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/tests"
 )
+
+var testFileFlag = flag.String("file", "", "Name of the file to run the test for")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
 
 type blocknativeTracerTest struct {
 	Genesis      *core.Genesis      `json:"genesis"`
@@ -44,8 +52,29 @@ type blocknativeTracerTest struct {
 
 func TestBlocknativeTracer(t *testing.T) {
 	log.Root().SetHandler(log.StreamHandler(os.Stdout, log.TerminalFormat(true)))
-	testBlocknativeTracer("blocknative", t)
-	testBlocknativeTracer("blocknative/with_decoding", t)
+
+	testsCases, err := loadTestTxs("blocknative")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decodingTestsCases, err := loadTestTxs("blocknative/with_decoding")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testsCases = append(testsCases, decodingTestsCases...)
+
+	for _, test := range testsCases {
+		if *testFileFlag != "" {
+			a := strings.ToLower(*testFileFlag)
+			b := strings.ToLower(test.name)
+			if a != b {
+				continue
+			}
+		}
+		t.Run(test.name, func(t *testing.T) {
+			executeTestCase(test, t, true)
+		})
+	}
 }
 
 func BenchmarkBlocknativeTracerWithoutDecoding(b *testing.B) {
@@ -139,19 +168,6 @@ func benchmarkBlocknativeTracer(b *testing.B, decode bool, dirPaths ...string) {
 	}
 }
 
-func testBlocknativeTracer(dirPath string, t *testing.T) {
-	testsCases, err := loadTestTxs(dirPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, test := range testsCases {
-		t.Run(test.name, func(t *testing.T) {
-			executeTestCase(test, t, true)
-		})
-	}
-}
-
 func loadTestTxs(dirPath string) ([]*blocknativeTracerTest, error) {
 	files, err := os.ReadDir(filepath.Join("testdata", dirPath))
 	if err != nil {
@@ -213,7 +229,14 @@ func loadTestTxs(dirPath string) ([]*blocknativeTracerTest, error) {
 			return nil, err
 		}
 
-		test.name = camel(strings.TrimSuffix(file.Name(), ".json"))
+		name := strings.TrimPrefix(dirPath, "blocknative")
+		name = strings.TrimPrefix(name, "/")
+		if name != "" {
+			name = name + "/"
+		}
+		name = name + camel(strings.TrimSuffix(file.Name(), ".json"))
+
+		test.name = name
 		test.evm = evm
 		test.tx = tx
 		test.msg = msg


### PR DESCRIPTION
This lets us specify specific tests to run using a `-file` flag, logging level with a `-loglevel` flag, and makes sure tests don't interfere with each other via the global cache.