### PR TITLE
tweak: Add logs back to block traces so they'll auto-show in mpex2.

### DIFF
--- a/eth/filters/trace_api.go
+++ b/eth/filters/trace_api.go
@@ -32,6 +32,7 @@ var defaultTxTraceOpts = blocknative.TracerOpts{
 var defaultBlockTraceOpts = blocknative.TracerOpts{
 	BalanceChanges:      true,
 	DisableBlockContext: true,
+	Logs:                true,
 }
 
 // TraceNewPendingTransactions creates a subscription that is triggered each time a


### PR DESCRIPTION
This reverts commit 6815d48a779f5d483c1ddcc876681cc919bc39ab.