### PR TITLE
fix: Don't panic if tokenID is nil

### DIFF
--- a/eth/tracers/blocknative/decoder/asset.go
+++ b/eth/tracers/blocknative/decoder/asset.go
@@ -2,9 +2,10 @@ package decoder
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"math/big"
 )
 
 var (

--- a/eth/tracers/blocknative/decoder/asset.go
+++ b/eth/tracers/blocknative/decoder/asset.go
@@ -70,8 +70,11 @@ func decodeERC721Metadata(evmCall evmCallFn, addr common.Address, tokenID *big.I
 	if metadata.Symbol, err = decodeMetadataSymbol(evmCall, addr); err != nil {
 		log.Trace("failed to decode ERC721 symbol", "err", err)
 	}
-	if metadata.URI, err = decodeMetadataTokenURI(evmCall, addr, tokenID); err != nil {
-		log.Trace("failed to decode ERC721 tokenURI", "err", err)
+
+	if tokenID != nil {
+		if metadata.URI, err = decodeMetadataTokenURI(evmCall, addr, tokenID); err != nil {
+			log.Trace("failed to decode ERC721 tokenURI", "err", err)
+		}
 	}
 
 	return metadata
@@ -82,8 +85,10 @@ func decodeERC1155Metadata(evmCall evmCallFn, addr common.Address, tokenID *big.
 	var err error
 	metadata := AssetMetadata{Type: AssetTypeERC1155}
 
-	if metadata.URI, err = decodeMetadataURI(evmCall, addr, tokenID); err != nil {
-		log.Trace("failed to decode ERC1155 URI", "err", err)
+	if tokenID != nil {
+		if metadata.URI, err = decodeMetadataURI(evmCall, addr, tokenID); err != nil {
+			log.Trace("failed to decode ERC1155 URI", "err", err)
+		}
 	}
 
 	return metadata


### PR DESCRIPTION
If for any reason the tokenID for an ERC721 or ERC1155 transfer is nil, skip calculating the URI. There is a most likely a better/more robust solution but this should prevent us from dying until such a solution is in place.

Example scenario: A Contract implements ERC1155, and additionally the same transfer method as ERC20. However the Contract is _not_ an ERC20 it just has one of the same methods. When we parse transfers, we will still collect this as a transfer but there is no tokenID because it's not an ERC1155 transfer. Later when getting metadata, we see that the contract is not an ERC20 but is an ERC1155 so we get the metadata for that. It is now not safe to assume the transfer has a non-nil tokenID.