### PR TITLE
tweak: Recover from any panics in trace streams.

### DIFF
--- a/eth/filters/trace_api.go
+++ b/eth/filters/trace_api.go
@@ -57,6 +57,14 @@ func (api *FilterAPI) NewPendingTransactionsWithTrace(ctx context.Context, trace
 		metricsPendingTxsNew.Inc(1)
 		defer metricsPendingTxsEnd.Inc(1)
 
+		// Recover from any panics. Should be the last deferred call so it runs
+		// first.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("pending_txs_stream panic:", r)
+			}
+		}()
+
 		for {
 			select {
 			case txs := <-txs:
@@ -174,6 +182,14 @@ func (api *FilterAPI) NewFullBlocksWithTrace(ctx context.Context, tracerOptsJSON
 
 		metricsBlocksNew.Inc(1)
 		defer metricsBlocksEnd.Inc(1)
+
+		// Recover from any panics. Should be the last deferred call so it runs
+		// first.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("block_stream panic:", r)
+			}
+		}()
 
 		var hashes []common.Hash
 		for {


### PR DESCRIPTION
This will ensure that panics in the tracer/decoder don't cause the entire node to restart. But no notification of the failure is indicated to the client, so it will simply stop seeing messages until it times out and reconnects on its own. A future improvement would be one of either sending the client a message telling it to reconnect or attempting to reconstruct a new go-routine transparently.