### PR TITLE
Fixes for balance changes

### DIFF
--- a/eth/tracers/blocknative/decoder/balances.go
+++ b/eth/tracers/blocknative/decoder/balances.go
@@ -83,6 +83,12 @@ func (changeMap balanceChangeByOwnerByAsset) addAssetTransfer(asset *Asset, from
 
 // accountAssetChange adds a single side change of an asset transfer to the balanceChangeByOwnerByAsset map.
 func (changeMap balanceChangeByOwnerByAsset) accountAssetChange(owner common.Address, counterparty common.Address, asset *Asset, delta *Amount) {
+	// We can get Transfer events that actually sent 0. We show these in the
+	// decoding and logs but don't add them to the balance changes.
+	if delta.ToInt().Sign() == 0 {
+		return
+	}
+
 	// If this is the first time we've seen this owner then create a new
 	// balanceByAsset map.
 	if _, ok := changeMap[owner]; !ok {

--- a/eth/tracers/blocknative/decoder/balances.go
+++ b/eth/tracers/blocknative/decoder/balances.go
@@ -18,22 +18,17 @@ func newBalances() *balances {
 	}
 }
 
-// captureCall decodes potential balance change data out of calldata.
-func (bt *balances) captureCall(sender common.Address, receiver common.Address, value *Amount, decoded *CallFrame) {
-	// Add the native transfer.
-	if value != nil && value.ToInt().Sign() > 0 {
-		bt.balanceChanges.addAssetTransfer(EthAsset, sender, receiver, value)
+// captureNativeTransfer handles native eth value transfers between call-frames
+// and for the top-level call.
+func (bt *balances) captureNativeTransfer(from, to common.Address, value *big.Int) {
+	if value != nil && value.Sign() > 0 {
+		bt.balanceChanges.addAssetTransfer(EthAsset, from, to, NewAmount(value))
 	}
+}
 
-	if decoded == nil {
-		return
-	}
-
-	// Add any decoded transfers.
-	for _, transfer := range decoded.Transfers {
-		// Add the decoded transfer now.
-		bt.balanceChanges.addAssetTransfer(transfer.Asset, transfer.From, transfer.To, transfer.Value)
-	}
+// captureDecodedTransfer decodes potential balance change data out of calldata.
+func (bt *balances) captureDecodedTransfer(transfer *Transfer) {
+	bt.balanceChanges.addAssetTransfer(transfer.Asset, transfer.From, transfer.To, transfer.Value)
 }
 
 // captureGas adds the gas payments to the balance changes.

--- a/eth/tracers/blocknative/decoder/decoder.go
+++ b/eth/tracers/blocknative/decoder/decoder.go
@@ -2,9 +2,10 @@ package decoder
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"math/big"
 )
 
 var (
@@ -31,17 +32,26 @@ func New(caches *Caches, evm evm) *Decoder {
 // If the call frame is determined to represent one or more Asset transfers we
 // add those too.
 func (d *Decoder) DecodeCallFrame(sender common.Address, receiver common.Address, value *big.Int, input []byte) (*CallFrame, error) {
+	// Always account for any eth transferred.
+	d.balances.captureNativeTransfer(sender, receiver, value)
+
+	// Decode the contract. As long as we can decode a contract we'll return
+	// a CallFrame object.
 	contract, err := d.DecodeContract(receiver)
 	if err != nil {
 		return nil, err
 	}
+	cf := &CallFrame{Contract: contract}
 
+	// Try to decode the call data. If we fail we'll still return the CallFrame
+	// we have.
 	callData, err := decodeCallData(sender, contract, input)
 	if err != nil {
-		return nil, err
+		return cf, err
 	}
+	cf.CallData = callData
 
-	// Add decoded Assets to any transfers.
+	// Decode and capture any calldata transfers.
 	for _, transfer := range callData.Transfers {
 		// Always add the assetID.
 		assetID := AssetID{Address: receiver, TokenID: transfer.TokenID}
@@ -54,11 +64,10 @@ func (d *Decoder) DecodeCallFrame(sender common.Address, receiver common.Address
 			continue
 		}
 		transfer.Asset.AssetMetadata = assetMetadata
+
+		// Account for the balance changes.
+		d.balances.balanceChanges.addAssetTransfer(transfer.Asset, transfer.From, transfer.To, transfer.Value)
 	}
-
-	cf := &CallFrame{Contract: contract, CallData: callData}
-
-	d.balances.captureCall(sender, receiver, NewAmount(value), cf)
 
 	return cf, nil
 }

--- a/eth/tracers/blocknative/tracer.go
+++ b/eth/tracers/blocknative/tracer.go
@@ -121,6 +121,11 @@ func (t *tracer) CaptureStart(evm *vm.EVM, from common.Address, to common.Addres
 func (t *tracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	finalizeCallFrame(&t.callStack[0], output, gasUsed, err)
 
+	// Add gas payments to balance changes iff the tx succeeded.
+	if err == nil && t.opts.Decode {
+		t.decoder.CaptureGas(t.evm.TxContext.Origin, t.evm.Context.Coinbase, gasUsed, t.evm.TxContext.GasPrice, t.evm.Context.BaseFee)
+	}
+
 	// If the user wants the logs, grab them from the state
 	if t.opts.Logs {
 		for _, stateLog := range t.evm.StateDB.Logs() {
@@ -130,11 +135,6 @@ func (t *tracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 				Topics:  stateLog.Topics,
 			})
 		}
-	}
-
-	// Add gas payments to balance changes
-	if t.opts.Decode {
-		t.decoder.CaptureGas(t.evm.TxContext.Origin, t.evm.Context.Coinbase, gasUsed, t.evm.TxContext.GasPrice, t.evm.Context.BaseFee)
 	}
 
 	// Add total time duration for this trace request

--- a/eth/tracers/internal/tracetest/testdata/blocknative/with_decoding/inner_create.json
+++ b/eth/tracers/internal/tracetest/testdata/blocknative/with_decoding/inner_create.json
@@ -796,6 +796,27 @@
     },
     "balanceChanges": [
       {
+        "address": "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+        "balanceChanges": [
+          {
+            "delta": "50573232556637",
+            "asset": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "type": "eth",
+              "name": "Ether",
+              "symbol": "ETH",
+              "decimals": 18
+            },
+            "breakdown": [
+              {
+                "counterparty": "0x741467b251fca923d6229c4b439078b55dca233b",
+                "amount": "50573232556637"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "address": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
         "balanceChanges": [
           {
@@ -820,7 +841,7 @@
         "address": "0x6c8f2a135f6ed072de4503bd7c4999a1a17f824b",
         "balanceChanges": [
           {
-            "delta": "3000000000000000000",
+            "delta": "0",
             "asset": {
               "address": "0x0000000000000000000000000000000000000000",
               "type": "eth",
@@ -832,6 +853,10 @@
               {
                 "counterparty": "0x7dd677b54fc954824a7bc49bd26cbdfa12c75adf",
                 "amount": "3000000000000000000"
+              },
+              {
+                "counterparty": "0x651913977e8140c323997fce5e03c19e0015eebf",
+                "amount": "-3000000000000000000"
               }
             ]
           }
@@ -841,7 +866,7 @@
         "address": "0x7dd677b54fc954824a7bc49bd26cbdfa12c75adf",
         "balanceChanges": [
           {
-            "delta": "-3000000000000000000",
+            "delta": "-62939549976892897",
             "asset": {
               "address": "0x0000000000000000000000000000000000000000",
               "type": "eth",
@@ -853,16 +878,20 @@
               {
                 "counterparty": "0x6c8f2a135f6ed072de4503bd7c4999a1a17f824b",
                 "amount": "-3000000000000000000"
+              },
+              {
+                "counterparty": "0x741467b251fca923d6229c4b439078b55dca233b",
+                "amount": "2937060450023107103"
               }
             ]
           }
         ]
       },
       {
-        "address": "0xb834e3edfc1a927bdcecb67a9d0eccbd752a5bb3",
+        "address": "0x651913977e8140c323997fce5e03c19e0015eebf",
         "balanceChanges": [
           {
-            "delta": "-65594100000000000",
+            "delta": "3000000000000000000",
             "asset": {
               "address": "0x0000000000000000000000000000000000000000",
               "type": "eth",
@@ -872,12 +901,66 @@
             },
             "breakdown": [
               {
+                "counterparty": "0x6c8f2a135f6ed072de4503bd7c4999a1a17f824b",
+                "amount": "3000000000000000000"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": "0xb834e3edfc1a927bdcecb67a9d0eccbd752a5bb3",
+        "balanceChanges": [
+          {
+            "delta": "7409523255663740",
+            "asset": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "type": "eth",
+              "name": "Ether",
+              "symbol": "ETH",
+              "decimals": 18
+            },
+            "breakdown": [
+              {
+                "counterparty": "0x741467b251fca923d6229c4b439078b55dca233b",
+                "amount": "73003623255663740"
+              },
+              {
                 "counterparty": "0x0000000000000000000000000000000000000000",
                 "amount": "-21923752181760"
               },
               {
                 "counterparty": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
                 "amount": "-65572176247818240"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": "0x741467b251fca923d6229c4b439078b55dca233b",
+        "balanceChanges": [
+          {
+            "delta": "-3010114646511327480",
+            "asset": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "type": "eth",
+              "name": "Ether",
+              "symbol": "ETH",
+              "decimals": 18
+            },
+            "breakdown": [
+              {
+                "counterparty": "0xb834e3edfc1a927bdcecb67a9d0eccbd752a5bb3",
+                "amount": "-73003623255663740"
+              },
+              {
+                "counterparty": "0xd3cda913deb6f67967b99d67acdfa1712c293601",
+                "amount": "-50573232556637"
+              },
+              {
+                "counterparty": "0x7dd677b54fc954824a7bc49bd26cbdfa12c75adf",
+                "amount": "-2937060450023107103"
               }
             ]
           }

--- a/eth/tracers/internal/tracetest/testdata/blocknative/with_decoding/multi_contracts_transfers.json
+++ b/eth/tracers/internal/tracetest/testdata/blocknative/with_decoding/multi_contracts_transfers.json
@@ -2855,6 +2855,30 @@
         "address": "0x6e715ab4f598eacf0016b9b35ef33e4141844ccc",
         "balanceChanges": [
           {
+            "delta": "-2",
+            "asset": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "decimals": 18,
+              "name": "Ether",
+              "symbol": "ETH",
+              "type": "eth"
+            },
+            "breakdown": [
+              {
+                "amount": "-80000000000000000000",
+                "counterparty": "0xad3ecf23c0c8983b07163708be6d763b5f056193"
+              },
+              {
+                "amount": "39999999999999999999",
+                "counterparty": "0xad3ecf23c0c8983b07163708be6d763b5f056193"
+              },
+              {
+                "amount": "39999999999999999999",
+                "counterparty": "0xad3ecf23c0c8983b07163708be6d763b5f056193"
+              }
+            ]
+          },
+          {
             "delta": "0",
             "asset": {
               "address": "0x304a554a310c7e546dfe434669c62820b7d83490"
@@ -3019,6 +3043,35 @@
               {
                 "counterparty": "0x4fd27b205895e698fa350f7ea57cec8a21927fcd",
                 "amount": "1213898080632835664204172"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": "0xad3ecf23c0c8983b07163708be6d763b5f056193",
+        "balanceChanges": [
+          {
+            "delta": "2",
+            "asset": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "type": "eth",
+              "name": "Ether",
+              "symbol": "ETH",
+              "decimals": 18
+            },
+            "breakdown": [
+              {
+                "counterparty": "0x6e715ab4f598eacf0016b9b35ef33e4141844ccc",
+                "amount": "80000000000000000000"
+              },
+              {
+                "counterparty": "0x6e715ab4f598eacf0016b9b35ef33e4141844ccc",
+                "amount": "-39999999999999999999"
+              },
+              {
+                "counterparty": "0x6e715ab4f598eacf0016b9b35ef33e4141844ccc",
+                "amount": "-39999999999999999999"
               }
             ]
           }


### PR DESCRIPTION
Change the order of operations when decoding call frames to address various balance change issues including:

- Missing native transfers to accounts that we fail to decode contracts for correctly.
- Unnecessary "0 transfers" that result from some calls.
- False gas transfer information on traces for reverting transactions.